### PR TITLE
Changes needed to run theta-l dycore in CAM on Derecho

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [ccs_config]
-tag = ccs_config_cesm0.0.47.nh
+tag = i_need_a_new_tag_here 
 protocol = git
 repo_url = https://github.com/jtruesdal/ccs_config_cesm
 local_path = ccs_config

--- a/src/dynamics/se/share/compose/cedr_kokkos.hpp
+++ b/src/dynamics/se/share/compose/cedr_kokkos.hpp
@@ -3,7 +3,6 @@
 
 #ifndef INCLUDE_CEDR_KOKKOS_HPP
 #define INCLUDE_CEDR_KOKKOS_HPP
-#define KOKKOS_VERSION 30401
 
 #include <Kokkos_Core.hpp>
 

--- a/src/dynamics/se/share/compose/cedr_util.hpp
+++ b/src/dynamics/se/share/compose/cedr_util.hpp
@@ -9,6 +9,9 @@
 #include "cedr_kokkos.hpp"
 #include "cedr_mpi.hpp"
 
+#include <sstream>  // For std::stringstream
+#include <iostream> // For std::cerr
+
 namespace cedr {
 namespace util {
 

--- a/src/dynamics/se/share/compose/compose_slmm.cpp
+++ b/src/dynamics/se/share/compose/compose_slmm.cpp
@@ -276,8 +276,6 @@ extern "C" {
 // Interface for Homme, through compose_mod.F90.
 void kokkos_init () {
   amb::dev_init_threads();
-  Kokkos::InitArguments args;
-  args.disable_warnings = true;
   initialize_kokkos();
   // Test these initialize correctly.
   Kokkos::View<int> v("hi");

--- a/src/dynamics/se/share/compose/compose_slmm_siqk.cpp
+++ b/src/dynamics/se/share/compose/compose_slmm_siqk.cpp
@@ -75,7 +75,7 @@ public:
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join (volatile value_type& dst, volatile value_type const& src) const {
+  void join (value_type& dst, value_type const& src) const {
     dst.max_nits = max(dst.max_nits, src.max_nits);
     dst.sum_nits += src.sum_nits;
     dst.nfails += src.nfails;


### PR DESCRIPTION
This PR adds the necessary changes to run the `theta-l` dycore in CAM on Derecho.

Note that a new `ccs_config` tag will be required before it can be tested on Derecho.