### PR TITLE
Use branch rather than tag for the ccs_config component

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [ccs_config]
-tag = i_need_a_new_tag_here 
+branch = ccs_config_cesm.nh
 protocol = git
 repo_url = https://github.com/jtruesdal/ccs_config_cesm
 local_path = ccs_config


### PR DESCRIPTION
This PR updates the `Externals.cfg` file to use John's `ccs_config_cesm.nh` branch for our SE-NH development work.

Once we have a finalized tag, we can change it back to use tag for checkout.