### PR TITLE
ali arms update - missing string.h include

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -51,7 +51,7 @@ required = True
 local_path = src/physics/ali_arms
 protocol = git
 repo_url = https://github.com/ESCOMP/ALI-ARMS
-tag = ALI_ARMS_v1.0.0
+tag = ALI_ARMS_v1.0.1
 required = True
 
 [atmos_phys]


### PR DESCRIPTION
Fixing a bug in stormspeed compile. ali-arms version update 1.0.1 has the fix as well as some blank space cleanup.  Should be bfb.