### PR TITLE
fix pressure error in Kessler: replace cube_mod with e3sm version and other bug fixes.

### DIFF
--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -7702,11 +7702,12 @@ Default: 0.
 
 
 <entry id="se_limiter_option" type="integer" category="se"
-       group="dyn_se_inparm" valid_values="0,4,8" >
+       group="dyn_se_inparm" valid_values="0,4,8,9" >
 Limiter used for horizontal tracer advection:
 0: None
 4: Sign-preserving limiter.
 8: Monotone limiter.
+9: CAAS monotone limiter.
 Default: 8
 </entry>
 


### PR DESCRIPTION
Kessler was showing banding errors in the pressure field after a few timesteps.  I was using the wrong version of cube_mod.F90 and replaced it with a slightly modified e3sm version.  I also discovered that I wasn't setting the use_moisture flag which is used in the theta-l dycore to identify moist pressure.  I also needed to initialize dp3d.  With these changes the pressure artifacts are gone.