### PR TITLE
Set vector length to 1 for DEBUG mode

### DIFF
--- a/src/dynamics/se/share/cxx/Config.hpp
+++ b/src/dynamics/se/share/cxx/Config.hpp
@@ -17,7 +17,11 @@
 # ifdef HOMMEXX_ENABLE_GPU
 #  define HOMMEXX_VECTOR_SIZE 1
 # else
-#  define HOMMEXX_VECTOR_SIZE 8
+#  ifndef NDEBUG
+#   define HOMMEXX_VECTOR_SIZE 1
+#  else
+#   define HOMMEXX_VECTOR_SIZE 8
+#  endif
 # endif
 #endif
 


### PR DESCRIPTION
As discussed in this issue #15 , when vectorization is enabled for Kokkos functions on CPU, there can be a spurious floating point exception if the array can not be divided evenly by the vector length and there is a padding with some garbage data.

To be consistent with E3SM, we set `HOMMEXX_VECTOR_SIZE=1` explicitly when DEBUG mode is turned on and checking floating point exception is desired.

fix #15 