### PR TITLE
bug fix for restarts

### DIFF
--- a/src/dynamics/senh/restart_dynamics.F90
+++ b/src/dynamics/senh/restart_dynamics.F90
@@ -1,258 +1,416 @@
 module restart_dynamics
-  use shr_kind_mod, only: r8 => shr_kind_r8
 
-  use dyn_comp,    only : dyn_import_t, dyn_export_t
-  use pio,         only : var_desc_t
-  use spmd_utils,  only : iam
-  use cam_logfile, only : iulog
-  use control_mod, only : theta_hydrostatic_mode
-  use perf_mod,    only : t_startf, t_stopf
+! Write and read dynamics fields from the restart file.  For exact restart
+! it is necessary to write all element data, including duplicate columns,
+! to the file.  The namelist option, se_write_restart_unstruct, is
+! available to write just the unique columns to the restart file using the
+! same unstructured grid used by the history and initial files.  This
+! results in the introduction of a roundoff size difference on restart, but
+! writes the fields in the unstructured grid format which is easier to
+! modify if the user desires to introduce perturbations or other
+! adjustments into the run.  The restart file containing the unstructured
+! grid format may also be used for an initial run.
 
-  implicit none
+use shr_kind_mod,     only: r8 => shr_kind_r8
+use spmd_utils,       only: iam, masterproc
+use control_mod,      only: theta_hydrostatic_mode
 
-  type(var_desc_t) :: udesc, vdesc, tdesc, psdesc, phisdesc, timedesc, &
-                      Wdesc, PHINHdesc
+use constituents,     only: cnst_name, pcnst
+!jtuse dyn_grid,         only: timelevel, fvm, elem, edgebuf
+use dyn_grid,         only: timelevel, elem
+use dyn_comp,         only: dyn_import_t, dyn_export_t, dyn_init, write_restart_unstruct
+use hycoef,           only: init_restart_hycoef, write_restart_hycoef, &
+                            hyai, hybi, ps0
+use ref_pres,         only: ptop_ref
 
-  type(var_desc_t) :: FQpsdesc, omegadesc
+use pio,              only: pio_global, pio_unlimited, pio_offset_kind, pio_int, pio_double, &
+                            pio_seterrorhandling, pio_bcast_error, pio_noerr, &
+                            file_desc_t, var_desc_t, io_desc_t, &
+                            pio_inq_dimid, pio_inq_dimlen, pio_inq_varid, &
+                            pio_def_dim, pio_def_var,  &
+                            pio_enddef, &
+                            pio_initdecomp, pio_freedecomp, pio_setframe, &
+                            pio_put_att, pio_put_var, pio_write_darray, &
+                            pio_get_att, pio_get_var, pio_read_darray
 
-  type(var_desc_t), pointer :: qdesc_dp(:)
+use cam_pio_utils,    only: pio_subsystem, cam_pio_handle_error
+use cam_grid_support, only: cam_grid_header_info_t, cam_grid_id, cam_grid_write_attr, &
+                            cam_grid_write_var, cam_grid_get_decomp, cam_grid_dimensions, &
+                            max_hcoordname_len, cam_grid_get_dim_names
+use ncdio_atm,        only: infld
 
-  integer :: ncol_dimid,  nlev_dimid, nlevp_dimid
-  public :: init_restart_dynamics
+use infnan,           only: isnan
+use cam_logfile,      only: iulog
+use cam_abortutils,   only: endrun
 
-  logical :: initialized=.false.
+use parallel_mod,     only: par
+use thread_mod,       only: horz_num_threads
+use dimensions_mod,   only: np, npsq, ne, nlev, qsize, nelemd, nc, ntrac, nlevp
+use dof_mod,          only: UniquePoints
+use element_mod,      only: element_t
+use time_mod,         only: tstep, TimeLevel_Qdp
+use edge_mod,         only : edgevpack_nlyr, edgevunpack_nlyr, edge_g
+use bndry_mod,        only: bndry_exchangeV
 
-CONTAINS
+use fvm_control_volume_mod, only: fvm_struct
 
-  subroutine init_restart_dynamics(File, dyn_out)
-    use pio, only : pio_global, pio_unlimited, pio_double, pio_def_dim, &
-         pio_put_att, pio_def_var,  &
-         pio_setdebuglevel, pio_inq_dimid, file_desc_t
-    use cam_pio_utils, only : pio_subsystem
-    use dimensions_mod, only : np, ne, nlev, qsize_d, nlevp, nelem , nelemd
-    use constituents, only : cnst_name
-    use dyn_grid, only : get_horiz_grid_dim_d
-    use hycoef, only: init_restart_hycoef
+implicit none
+private
+save
 
-    type(file_desc_t),  intent(inout) :: file
-    type(dyn_export_t), intent(in)    :: dyn_out
+public :: &
+   init_restart_dynamics,  &
+   write_restart_dynamics, &
+   read_restart_dynamics
 
-    integer :: vdimids(2)
-    integer :: ierr, i, dummy, j, k, ie
-    integer :: timelevels_dimid
-
-    call init_restart_hycoef(File, vdimids)
-
-    call PIO_Setdebuglevel(0)
-    ierr = PIO_Def_Dim(File,'ncol_d',nelem*np*np,ncol_dimid)
-
-    ierr = PIO_Def_Dim(File,'timelevels',PIO_UNLIMITED,timelevels_dimid)
-
-    nlev_dimid = vdimids(1)
-    nlevp_dimid = vdimids(2)
-
-
-    ierr = PIO_Put_Att(File, PIO_GLOBAL, 'ne', ne)
-    ierr = PIO_Put_Att(File, PIO_GLOBAL, 'np', np)
-
-    ierr = PIO_Def_Var(File, 'time', pio_double, (/timelevels_dimid/), timedesc)
-
-    ierr = PIO_Def_Var(File, 'U', pio_double, (/ncol_dimid, nlev_dimid, timelevels_dimid/), Udesc)
-    ierr = PIO_Def_Var(File, 'V', pio_double, (/ncol_dimid, nlev_dimid, timelevels_dimid/), Vdesc)
+! these variables are module data so they can be shared between the
+! file definition and write phases
+type(var_desc_t)              :: ps_desc, udesc, vdesc, tdesc, omegadesc, phisdesc
 #ifdef MODEL_THETA_L
-    ierr = PIO_Def_Var(File, 'VTheta_dp', pio_double, (/ncol_dimid, nlev_dimid, timelevels_dimid/), Tdesc)
+type(var_desc_t)              :: wdesc, PHINHdesc
+#endif
+type(var_desc_t), allocatable :: qdesc_dp(:)
+type(var_desc_t)              :: dp_fvm_desc
+type(var_desc_t), pointer     :: c_fvm_desc(:)
+
+integer, private :: nelem_tot = -1 ! Correct total number of elements
+
+!=========================================================================================
+CONTAINS
+!=========================================================================================
+
+subroutine init_nelem_tot()
+  use spmd_utils, only: mpicom, MPI_INTEGER, MPI_SUM
+
+  integer :: ierr
+
+  if (nelem_tot < 0) then
+    call MPI_Allreduce(nelemd, nelem_tot, 1, MPI_INTEGER, MPI_SUM, mpicom, ierr)
+  end if
+end subroutine init_nelem_tot
+
+subroutine init_restart_dynamics(file, dyn_out)
+
+   ! Define dimensions, variables, attributes for restart file.
+
+   ! This is not really an "init" routine.  It is called before
+   ! write_restart_dynamics every time an restart is written.
+
+   ! arguments
+   type(file_desc_t),  intent(inout) :: file
+   type(dyn_export_t), intent(in)    :: dyn_out
+
+   ! local variables
+   integer :: i
+   integer :: vdimids(2)
+   integer :: nlev_dimid
+   integer :: nlevp_dimid
+   integer :: ncol_dimid
+   integer :: ncol_fvm_dimid
+   integer :: time_dimid
+
+   integer :: ierr, err_handling
+
+   integer :: grid_id
+   type(cam_grid_header_info_t) :: info
+
+   !----------------------------------------------------------------------------
+
+   call init_nelem_tot()
+   call init_restart_hycoef(file, vdimids)
+   nlev_dimid = vdimids(1)
+   nlevp_dimid = vdimids(2)
+
+   call pio_seterrorhandling(File, pio_bcast_error, err_handling)
+
+   ierr = PIO_Def_Dim(File, 'time', PIO_UNLIMITED, time_dimid)
+
+   ! GLL restart fields
+
+   ! number of columns written to restart depends on whether all columns in the
+   ! element structures are written, or just the unique columns (unstructured grid)
+   if (write_restart_unstruct) then
+      grid_id = cam_grid_id('GLL')
+      call cam_grid_write_attr(File, grid_id, info)
+      ncol_dimid = info%get_hdimid(1)
+   else
+      ierr = PIO_Def_Dim(File,'nenpnp', nelem_tot*np*np, ncol_dimid)
+      ierr = PIO_Put_Att(File, PIO_GLOBAL, 'ne', ne)
+      ierr = PIO_Put_Att(File, PIO_GLOBAL, 'np', np)
+   end if
+
+   ierr = PIO_Def_Var(File, 'PS', pio_double, (/ncol_dimid, time_dimid/), ps_desc)
+   ierr = PIO_Def_Var(File, 'OMEGA', pio_double, (/ncol_dimid, nlev_dimid/), omegadesc)
+   ierr = PIO_Def_Var(File, 'PHIS', pio_double, (/ncol_dimid/), phisdesc)
+   ierr = PIO_Def_Var(File, 'U', pio_double, (/ncol_dimid, nlev_dimid, time_dimid/), Udesc)
+   ierr = PIO_Def_Var(File, 'V', pio_double, (/ncol_dimid, nlev_dimid, time_dimid/), Vdesc)
+#ifdef MODEL_THETA_L
+    ierr = PIO_Def_Var(File, 'VTheta_dp', pio_double, (/ncol_dimid, nlev_dimid, time_dimid/), Tdesc)
     if( .not. theta_hydrostatic_mode ) then
-       ierr = PIO_Def_Var(File, 'W', pio_double, (/ncol_dimid, nlevp_dimid, timelevels_dimid/), Wdesc)
-       ierr = PIO_Def_Var(File, 'PHINH', pio_double, (/ncol_dimid, nlevp_dimid, timelevels_dimid/), PHINHdesc)
+       ierr = PIO_Def_Var(File, 'W', pio_double, (/ncol_dimid, nlevp_dimid, time_dimid/), Wdesc)
+       ierr = PIO_Def_Var(File, 'PHINH', pio_double, (/ncol_dimid, nlevp_dimid, time_dimid/), PHINHdesc)
     endif
 #else
-    ierr = PIO_Def_Var(File, 'T', pio_double, (/ncol_dimid, nlev_dimid, timelevels_dimid/), Tdesc)
+   ierr = PIO_Def_Var(File, 'T', pio_double, (/ncol_dimid, nlev_dimid, time_dimid/), Tdesc)
 #endif
-    !
-    ! Omega is not strictly needed, it could be rederived - but this is easier
-    !
+   allocate(qdesc_dp(qsize))
 
-    ierr = PIO_Def_Var(File, 'OMEGA', pio_double, (/ncol_dimid, nlev_dimid/), omegadesc)
-    ierr = PIO_Def_Var(File, 'PS', pio_double, (/ncol_dimid, timelevels_dimid/), PSdesc)
-    ierr = PIO_Def_Var(File, 'PHIS', pio_double, (/ncol_dimid/), phisdesc)
+   do i=1,qsize
+      ierr = PIO_Def_Var(File,"dp"//trim(cnst_name(i)), pio_double, &
+                         (/ncol_dimid, nlev_dimid, time_dimid/), Qdesc_dp(i))
+   end do
 
-    allocate(qdesc_dp(qsize_d))
+   ! CSLAM restart fields
 
-    do i=1,qsize_d
-       ierr = PIO_Def_Var(File,"dp"//cnst_name(i), pio_double, (/ncol_dimid, nlev_dimid, timelevels_dimid/), Qdesc_dp(i))
-    end do
+   if (ntrac > 0) then
 
-  end subroutine init_restart_dynamics
+      grid_id = cam_grid_id('FVM')
+      call cam_grid_write_attr(File, grid_id, info)
+      ncol_fvm_dimid = info%get_hdimid(1)
+
+      ierr = PIO_Def_Var(File, 'dp_fvm', pio_double, &
+         (/ncol_fvm_dimid, nlev_dimid, time_dimid/), dp_fvm_desc)
+
+      allocate(c_fvm_desc(ntrac))
+      do i = 1, ntrac
+         ierr = PIO_Def_Var(File, trim(cnst_name(i))//"_fvm", pio_double, &
+            (/ncol_fvm_dimid, nlev_dimid, time_dimid/), c_fvm_desc(i))
+      end do
+
+   end if
+
+   call pio_seterrorhandling(File, err_handling)
+
+end subroutine init_restart_dynamics
+
+!=========================================================================================
+
+subroutine write_restart_dynamics(File, dyn_out)
+  use control_mod,      only: qsplit
+   type(file_desc_t), intent(inout) :: File
+   type(dyn_export_t), intent(in)   :: dyn_out
+
+   ! local variables
+   integer(pio_offset_kind), parameter :: t_idx = 1
+
+   type(element_t),  pointer :: elem(:)
+   type(fvm_struct), pointer :: fvm(:)
+
+   integer :: tl, tlqdp
+   integer :: i, ie, ii, j, k, m
+   integer :: ierr
+
+   integer :: grid_id
+   integer :: grid_dimlens(2)
 
 
-  subroutine write_restart_dynamics(File, dyn_out)
-    use pio, only : pio_offset_kind, io_desc_t, pio_double, pio_write_darray, &
-         pio_put_var, pio_initdecomp, pio_setframe, &
-         pio_freedecomp, pio_enddef, file_desc_t
-    use cam_pio_utils, only : pio_subsystem
-    use dyn_grid, only : timelevel
-    use control_mod, only: qsplit
-    use time_mod, only : tstep, TimeLevel_Qdp
-    use element_mod, only : element_t
-    use dimensions_mod, only : nlev, qsize_d, nlevp, np, ne, nelemd, nelem
-    use dof_mod, only : UniquePoints
-    use time_manager, only: get_curr_time
-    use parallel_mod, only: par
-    use hycoef, only: write_restart_hycoef
-    use cam_abortutils,   only: endrun
 
-    implicit none
-    type(file_desc_t) :: File
-    type(dyn_export_t), intent(in)  :: dyn_out
+   integer :: array_lens(3)
+   integer :: file_lens(2)
+   type(io_desc_t), pointer :: iodesc3d_fvm
+   real(r8),    allocatable :: buf3d(:,:,:)
 
-    type(io_desc_t) :: iodesc2d, iodesc3d, iodesc3dp
-    integer :: st, ie, k, en, tl, tlQdp, ierr, q
-    integer(kind=pio_offset_kind), parameter :: t = 1
 
-    real(kind=r8),pointer :: vartmp(:,:,:), var3d(:,:,:,:), var3dp(:,:,:,:), var2d(:,:,:)
-    integer :: i, j
 
-    type(element_t), pointer :: elem(:)
-    real(kind=r8) :: time
-    integer :: ndcur, nscur
-    integer(kind=pio_offset_kind), pointer :: ldof(:)
+   character(len=*), parameter :: sub = 'write_restart_dynamics'
+   !----------------------------------------------------------------------------
 
-    call write_restart_hycoef(File)
+   call write_restart_hycoef(File)
 
-   if (par%dynproc) then
-    elem => dyn_out%elem
+   tl = timelevel%n0
+   call TimeLevel_Qdp(timelevel, qsplit, tlQdp)
+
+   if (iam .lt. par%nprocs) then
+      elem => dyn_out%elem
+#ifndef MODEL_THETA_L
+      fvm => dyn_out%fvm
+#endif
    else
-    allocate (elem(0))
+      allocate (elem(0), fvm(0))
    endif
 
-    ldof => get_restart_decomp(elem, 1)
-    call PIO_InitDecomp(pio_subsystem, pio_double, (/nelem*np*np/) , ldof , iodesc2d)
-    deallocate(ldof)
+   ! write fields on GLL grid
 
-    ldof => get_restart_decomp(elem, nlev)       
-    call PIO_InitDecomp(pio_subsystem, pio_double, (/nelem*np*np,nlev/),ldof , iodesc3d)
-    deallocate(ldof)
+   if (write_restart_unstruct) then
+      call write_unstruct()
+   else
+      call write_elem()
+   end if
+
+   ! write CSLAM fields
+
+   if (ntrac > 0) then
+
+      grid_id = cam_grid_id('FVM')
+
+      ! write coords for FVM grid
+      call cam_grid_write_var(File, grid_id)
+
+      call cam_grid_dimensions(grid_id, grid_dimlens)
+      allocate(buf3d(nc*nc,nlev,nelemd))
+      array_lens = (/nc*nc, nlev, nelemd/)
+      file_lens  = (/grid_dimlens(1), nlev/)
+      call cam_grid_get_decomp(grid_id, array_lens, file_lens, pio_double, iodesc3d_fvm)
+
+      do ie = 1, nelemd
+         do k = 1, nlev
+            ii = 1
+            do j = 1, nc
+               do i = 1, nc
+!jt                  buf3d(ii,k,ie) = fvm(ie)%dp_fvm(i,j,k)
+                  ii = ii + 1
+               end do
+            end do
+         end do
+      end do
+      call PIO_Setframe(file, dp_fvm_desc, t_idx)
+      call PIO_Write_Darray(file, dp_fvm_desc, iodesc3d_fvm, buf3d, ierr)
+
+      do m = 1, ntrac
+         do ie = 1, nelemd
+            do k = 1, nlev
+               ii = 1
+               do j = 1, nc
+                  do i = 1, nc
+!jt                     buf3d(ii,k,ie) = fvm(ie)%c(i,j,k,m)
+                     ii = ii + 1
+                  end do
+               end do
+            end do
+         end do
+         call PIO_Setframe(file, c_fvm_desc(m), t_idx)
+         call PIO_Write_Darray(file, c_fvm_desc(m), iodesc3d_fvm, buf3d, ierr)
+      end do
+
+      deallocate(c_fvm_desc)
+      deallocate(buf3d)
+      ! should this call be made on a pointer?
+      !call pio_freedecomp(File, iodesc3d_fvm)
+
+   end if
+
+   if (iam >= par%nprocs) then
+      deallocate(elem, fvm)
+   endif
+
+!-------------------------------------------------------------------------------
+contains
+!-------------------------------------------------------------------------------
+
+subroutine write_elem()
+
+   ! local variables
+   integer          :: i, ie, j, k
+   integer          :: ierr
+   integer, pointer :: ldof(:)
+
+   type(io_desc_t)  :: iodesc2d, iodesc3d
+   real(kind=r8), pointer :: var3d(:,:,:,:), var2d(:,:,:)
+#ifdef MODEL_THETA_L
+   type(io_desc_t)  :: iodesc3dp
+   real(kind=r8), pointer :: var3dp(:,:,:,:)
+#endif
+   !----------------------------------------------------------------------------
+
+   ldof => get_restart_decomp(elem, 1)
+   call PIO_InitDecomp(pio_subsystem, pio_double, (/nelem_tot*np*np/), ldof, iodesc2d)
+   deallocate(ldof)
+
+   ldof => get_restart_decomp(elem, nlev)
+   call PIO_InitDecomp(pio_subsystem, pio_double, (/nelem_tot*np*np,nlev/), ldof, iodesc3d)
+   deallocate(ldof)
 
 #ifdef MODEL_THETA_L
     if( .not. theta_hydrostatic_mode ) then
        ldof => get_restart_decomp(elem, nlevp)
-       call PIO_InitDecomp(pio_subsystem, pio_double, (/nelem*np*np,nlevp/),ldof , iodesc3dp)
+       call PIO_InitDecomp(pio_subsystem, pio_double, (/nelem_tot*np*np,nlevp/),ldof , iodesc3dp)
        deallocate(ldof)
     endif
 #endif
-    initialized = .true.
-    
 
-    call get_curr_time(ndcur, nscur)
-
-    allocate(vartmp(np,np,nlev))
-    en=0
-    do ie=1,nelemd
-       en=en+elem(ie)%idxp%NumUniquePts
-    end do
-
-    allocate(var2d(np,np,nelemd ))
-
-    allocate(var3d(np,np,nelemd,nlev))
-
+   allocate(var2d(np,np,nelemd))
+   allocate(var3d(np,np,nelemd,nlev))
 #ifdef MODEL_THETA_L
-    if( .not. theta_hydrostatic_mode ) then
-       allocate(var3dp(np,np,nelemd,nlevp))
-    endif
+   allocate(var3dp(np,np,nelemd,nlevp))
 #endif
 
-!$omp parallel do private(ie, j, i)
-    do ie=1,nelemd
-       do j=1,np
-          do i=1,np
-             var2d(i,j,ie) = elem(ie)%state%phis(i,j)
-          end do
-       end do
-    end do
-    call PIO_Write_Darray(File,Phisdesc,iodesc2d, var2d,ierr)
+   !$omp parallel do num_threads(horz_num_threads) private(ie, j, i)
+   do ie = 1, nelemd
+      do j = 1, np
+         do i = 1, np
+            var2d(i,j,ie) = elem(ie)%state%phis(i,j)
+         end do
+      end do
+   end do
+   call PIO_Write_Darray(File, phisdesc, iodesc2d, var2d, ierr)
 
-!$omp parallel do private(ie, k, j, i)
-    do ie=1,nelemd
-       do k=1,nlev
-          do j=1,np
-             do i=1,np
-                var3d(i,j,ie,k) = elem(ie)%derived%omega_p(i,j,k)
-             end do
-          end do
-       end do
-    end do
-    call PIO_Write_Darray(File,omegadesc,iodesc3d, var3d,ierr)
+   !$omp parallel do num_threads(horz_num_threads) private(ie, k, j, i)
+   do ie = 1, nelemd
+      do k = 1, nlev
+         do j = 1, np
+            do i = 1, np
+               var3d(i,j,ie,k) = elem(ie)%derived%omega_p(i,j,k)
+            end do
+         end do
+      end do
+   end do
+   call PIO_Write_Darray(File, omegadesc, iodesc3d, var3d, ierr)
 
+   !$omp parallel do num_threads(horz_num_threads) private(ie, j, i)
+   do ie = 1, nelemd
+      do j = 1, np
+         do i = 1, np
+            var2d(i,j,ie) = elem(ie)%state%ps_v(i,j,tl)
+         end do
+      end do
+   end do
+   call PIO_Setframe(File, ps_desc, t_idx)
+   call PIO_Write_Darray(File, ps_desc, iodesc2d, var2d, ierr)
 
-    tl = timelevel%n0
-    call TimeLevel_Qdp(timelevel, qsplit, tlQdp)
-    time = ndcur+real(nscur,kind=r8)/86400._r8
+   !$omp parallel do num_threads(horz_num_threads) private(ie, k, j, i)
+   do ie = 1, nelemd
+      do k = 1, nlev
+         do j = 1, np
+            do i = 1, np
+               var3d(i,j,ie,k) = elem(ie)%state%V(i,j,1,k,tl)
+            end do
+         end do
+      end do
+   end do
+   call PIO_Setframe(File, Udesc, t_idx)
+   call PIO_Write_Darray(File, Udesc, iodesc3d, var3d, ierr)
 
-    ierr = pio_put_var(File,timedesc%varid, (/int(t)/), time)
+   !$omp parallel do num_threads(horz_num_threads) private(ie, k, j, i)
+   do ie = 1, nelemd
+      do k = 1, nlev
+         do j = 1, np
+            do i = 1, np
+               var3d(i,j,ie,k) = elem(ie)%state%V(i,j,2,k,tl)
+            end do
+         end do
+      end do
+   end do
+   call PIO_Setframe(File, Vdesc, t_idx)
+   call PIO_Write_Darray(File, Vdesc, iodesc3d, var3d, ierr)
 
-!$omp parallel do private(ie, j, i)
-    do ie=1,nelemd
-       do j=1,np
-          do i=1,np
-             var2d(i,j,ie) = elem(ie)%state%ps_v(i,j,tl)
-          end do
-       end do
-    end do
-    call PIO_Setframe(File,PSdesc, t)
-    call PIO_Write_Darray(File,PSdesc,iodesc2d, var2d,ierr)
-
-    ! Write the U component of Velocity
-!$omp parallel do private(ie, k, j, i)
-    do ie=1,nelemd
-       do k=1,nlev
-          do j=1,np
-             do i=1,np
-                var3d(i,j,ie,k) = elem(ie)%state%V(i,j,1,k,tl)
-             end do
-          end do
-       end do
-    end do
-
-
-    call PIO_Setframe(File,Udesc, t)
-    call PIO_Write_Darray(File,Udesc,iodesc3d,var3d,ierr)
-
-
-       ! Write the V component of Velocity
-!$omp parallel do private(ie, k, j, i)
-    do ie=1,nelemd
-       do k=1,nlev
-          do j=1,np
-             do i=1,np
-                var3d(i,j,ie,k) = elem(ie)%state%V(i,j,2,k,tl)
-             end do
-          end do
-       end do
-    end do
-
-    call PIO_Setframe(File,Vdesc, t)
-    call PIO_Write_Darray(File,Vdesc,iodesc3d,var3d,ierr)
-
-    ! Write T
-!$omp parallel do private(ie, k, j, i)
-    do ie=1,nelemd
-       do k=1,nlev
-          do j=1,np
-             do i=1,np
+   !$omp parallel do num_threads(horz_num_threads) private(ie, k, j, i)
+   do ie = 1, nelemd
+      do k = 1, nlev
+         do j = 1, np
+            do i = 1, np
 #ifdef MODEL_THETA_L
                 var3d(i,j,ie,k) = elem(ie)%state%VTheta_dp(i,j,k,tl)
 #else
-                var3d(i,j,ie,k) = elem(ie)%state%T(i,j,k,tl)
+               var3d(i,j,ie,k) = elem(ie)%state%T(i,j,k,tl)
 #endif
-             end do
-          end do
-       end do
-    end do
+            end do
+         end do
+      end do
+   end do
+   call PIO_Setframe(File, Tdesc, t_idx)
+   call PIO_Write_Darray(File, Tdesc, iodesc3d, var3d, ierr)
 
-    call PIO_Setframe(File,Tdesc, t)
-    call PIO_Write_Darray(File,Tdesc,iodesc3d,var3d,ierr)
-
-#ifdef MODEL_THETA_L    
+#ifdef MODEL_THETA_L
     if( .not. theta_hydrostatic_mode )then
     ! Write W
 !$omp parallel do private(ie, k, j, i)
@@ -265,7 +423,7 @@ CONTAINS
              end do
           end do
        end do
-       call PIO_Setframe(File,Wdesc, t)
+       call PIO_Setframe(File,Wdesc, t_idx)
        call PIO_Write_Darray(File,Wdesc,iodesc3dp,var3dp,ierr)
 
     ! Write Phi
@@ -279,370 +437,1003 @@ CONTAINS
              end do
           end do
        end do
-       call PIO_Setframe(File,PHINHdesc, t)
+       call PIO_Setframe(File,PHINHdesc, t_idx)
        call PIO_Write_Darray(File,PHINHdesc,iodesc3dp,var3dp,ierr)
     endif
 #endif
 
+    do m = 1, qsize
 
-    do q=1,qsize_d
+      !$omp parallel do num_threads(horz_num_threads) private(ie, k, j, i)
+      do ie = 1, nelemd
+         do k = 1, nlev
+            do j = 1, np
+               do i = 1, np
+                  var3d(i,j,ie,k) = elem(ie)%state%Qdp(i,j,k,m,tlQdp)
+               end do
+            end do
+         end do
+      end do
+      call PIO_Setframe(File, Qdesc_dp(m), t_idx)
+      call PIO_Write_Darray(File, Qdesc_dp(m), iodesc3d, var3d, ierr)
 
-       ! Write Q
-!$omp parallel do private(ie, k, j, i)
-       do ie=1,nelemd
-          do k=1,nlev
-             do j=1,np
-                do i=1,np
-                   var3d(i,j,ie,k) = elem(ie)%state%Qdp(i,j,k,q,tlQdp)
-                end do
-             end do
-          end do
-       end do
-       call PIO_Setframe(File,Qdesc_dp(q), t)
-       call PIO_Write_Darray(File,Qdesc_dp(q),iodesc3d,var3d,ierr)
+   end do
 
-    end do
-
-
-    deallocate(var3d)
-    deallocate(var2d)
-    deallocate(qdesc_dp)
-    call pio_freedecomp(File, iodesc2d)
-    call pio_freedecomp(File, iodesc3d)
+   deallocate(var2d)
+   deallocate(var3d)
 #ifdef MODEL_THETA_L
     if( .not. theta_hydrostatic_mode ) then
        deallocate(var3dp)
        call pio_freedecomp(File, iodesc3dp)
     endif
 #endif
-
-
-   if (par%dynproc) then
-   else
-    deallocate(elem)
-   endif  !!  par%dynproc
-
-  end subroutine write_restart_dynamics
-
-  !
-  ! Get the integer mapping of a variable in the dynamics decomp in memory.  
-  ! The canonical ordering is as on the file. A 0 value indicates that the
-  ! variable is not on the file (eg halo or boundary values)
-  !
-
-  function get_restart_decomp(elem, lev) result(ldof)
-    use element_mod, only : element_t
-    use dimensions_mod, only : np, nelemd, nelem
-    use pio, only: pio_offset_kind
-    type(element_t), intent(in) :: elem(:)
-    integer(kind=pio_offset_kind), pointer :: ldof(:)
-    integer, intent(in) :: lev
-
-    integer ::  i, j, k, ie
-
-    j=1
-
-    allocate(ldof(nelemd*np*np*lev))
-    do k=1,lev
-       do ie=1,nelemd
-          do i=1,np*np
-             ldof(j) = int(elem(ie)%GlobalID-1, pio_offset_kind)*np*np &
-                     + int(k-1, pio_offset_kind)*nelem*np*np + i
-             j=j+1
-          end do
-       end do
-    end do
-
-  end function get_restart_decomp
-
-
-  subroutine read_restart_dynamics (File, dyn_in, dyn_out)
-    ! for restart and initial condition, timelevel == timelevel_dyn
-    ! so we wont update this routine to use both  
-    use dyn_grid, only : timelevel, elem
-    use pio, only : file_desc_t, pio_global, pio_double, pio_offset_kind, &
-         pio_get_att, pio_inq_dimid, pio_inq_dimlen, pio_initdecomp, pio_inq_varid, &
-         pio_read_darray, pio_setframe, file_desc_t, io_desc_t, pio_double
-    use dyn_comp, only : dyn_init
-    use dimensions_mod, only : nlev, nlevp, np, ne, nelemd, qsize_d
-    use cam_abortutils,   only: endrun
-    use constituents, only : cnst_name
-    use cam_pio_utils, only : pio_subsystem
-    use control_mod,            only: qsplit
-    use time_mod,               only: TimeLevel_Qdp
-
-    !
-    ! Input arguments
-    !
-    type(File_desc_t), intent(inout) :: File
-    type(dyn_import_t), intent(inout)  :: dyn_in
-    type(dyn_export_t), intent(inout)  :: dyn_out
-
-    type(io_desc_t) :: iodesc2d, iodesc3d, iodesc3dp
-    real(r8), allocatable :: var3d(:), var3dp(:), var2d(:)
-    integer :: ie, ierr, fne, fnp, fnlev
-    integer :: ncols
-    integer(kind=pio_offset_kind), pointer :: ldof(:)
-    integer(kind=pio_offset_kind), parameter :: t = 1
-    integer :: i, k, cnt, st, en, tl, tlQdp, ii, jj, s2d, q, j
-    integer :: timelevel_dimid, timelevel_chk
-    integer :: npes_se
-!    type(file_desc_t) :: ncid
-!    integer :: ncid
-
-    ierr = PIO_Get_Att(File, PIO_GLOBAL, 'ne', fne)
-    ierr = PIO_Get_Att(File, PIO_GLOBAL, 'np', fnp)
-
-    if(ne/=fne .or. np/=fnp) then
-       write(iulog,*) 'Restart file np or ne does not match model. np (file, model):',fnp,np,&
-            ' ne (file, model) ', fne, ne
-       call endrun()
-    end if
-
-    ierr = PIO_Inq_DimID(File, 'lev', nlev_dimid)
-    ierr = PIO_Inq_dimlen(File, nlev_dimid, fnlev)
-    if(ne/=fne .or. np/=fnp) then
-       write(iulog,*) 'Restart file nlev does not match model. nlev (file, namelist):',fnlev, nlev
-       call endrun()
-    end if
-
-    ierr = PIO_Inq_DimID(File, 'timelevels', timelevel_dimid)
-    ierr = PIO_Inq_dimlen(File, timelevel_dimid, timelevel_chk)
-
-
-    ierr = PIO_Inq_DimID(File, 'ncol_d', ncol_dimid)
-
-    ierr = PIO_Inq_dimlen(File, ncol_dimid, ncols)
-
-
-    ldof => get_restart_decomp(elem, 1)
-    s2d=size(ldof)
-    allocate(var3d(s2d*nlev), var2d(s2d))
-
-    var2d = 0._r8
-    var3d = 0._r8
-    call PIO_InitDecomp(pio_subsystem, pio_double, (/ncols/) , ldof , iodesc2d)
-    deallocate(ldof)
-
-    ldof => get_restart_decomp(elem, nlev)
-    call PIO_InitDecomp(pio_subsystem, pio_double, (/ncols,nlev/),ldof , iodesc3d)
-    deallocate(ldof)
-
-#ifdef MODEL_THETA_L
-    if ( .not. theta_hydrostatic_mode ) then
-       allocate(var3dp(s2d*nlevp))
-       var3dp = 0.0
-    endif
-
-    ldof => get_restart_decomp(elem, nlevp)
-    call PIO_InitDecomp(pio_subsystem, pio_double, (/ncols,nlevp/),ldof , iodesc3dp)
-    deallocate(ldof)
-#endif
-
-
-    initialized = .true.
-
-    ierr = PIO_Inq_varid(File, 'U', udesc)
-
-    ierr = PIO_Inq_varid(File, 'V', Vdesc)
-
-#ifdef MODEL_THETA_L
-    ierr = PIO_Inq_varid(File, 'VTheta_dp', tdesc)
-#else
-    ierr = PIO_Inq_varid(File, 'T', tdesc)
-#endif
-
-    ierr = PIO_Inq_varid(File, 'OMEGA', OMEGAdesc)
-
-    ierr = PIO_Inq_varid(File, 'PS', psdesc)
-
-    ierr = PIO_Inq_varid(File, 'PHIS', phisdesc)
-
-#ifdef MODEL_THETA_L
-    if ( .not. theta_hydrostatic_mode ) then
-       ierr = PIO_Inq_varid(File, 'W', Wdesc)
-       ierr = PIO_Inq_varid(File, 'PHINH', PHINHdesc)
-    endif
-#endif
-
-    allocate(qdesc_dp(qsize_d))
-
-    do q=1,qsize_d
-       ierr = PIO_Inq_varid(File, "dp"//cnst_name(q) ,Qdesc_dp(q))
-    end do
-
-    call pio_setframe(File,phisdesc, int(1,kind=pio_offset_kind))
-
-    call pio_read_darray(File, phisdesc, iodesc2d, var2d, ierr)
-
-    cnt=0
-    do ie=1,nelemd
-       do j=1,np
-          do i=1,np
-             cnt=cnt+1
-             elem(ie)%state%phis(i,j) = var2d(cnt)
-          end do
-       end do
-    end do
-
-
-    do ie=1,nelemd
-       elem(ie)%derived%fM = 0._r8
-       elem(ie)%derived%fT = 0._r8
-       elem(ie)%derived%fQ = 0._r8
-       elem(ie)%state%Q = 0._r8
-    end do
-
-    call pio_read_darray(File, omegadesc, iodesc3d, var3d, ierr)
-    cnt=0
-
-    do k=1,nlev
-       do ie=1,nelemd
-          do j=1,np
-             do i=1,np
-                cnt=cnt+1
-                elem(ie)%derived%omega_p(i,j,k) = var3d(cnt)
-             end do
-          end do
-       end do
-    end do
-
-
-    tl = timelevel%n0
-    call TimeLevel_Qdp(timelevel, qsplit, tlQdp)
-
-    call pio_setframe(File,psdesc, t)
-    call pio_read_darray(File, psdesc, iodesc2d, var2d, ierr)
-
-    cnt=0
-    do ie=1,nelemd
-       do j=1,np
-          do i=1,np
-             cnt=cnt+1
-             elem(ie)%state%ps_v(i,j,tl) = var2d(cnt)
-          end do
-       end do
-    end do
-
-    call pio_setframe(File,udesc, t)
-    call pio_read_darray(File, udesc, iodesc3d, var3d, ierr)
-
-    cnt=0
-    do k=1,nlev
-       do ie=1,nelemd
-          do j=1,np
-             do i=1,np
-                cnt=cnt+1
-                elem(ie)%state%v(i,j,1,k,tl) = var3d(cnt)
-             end do
-          end do
-       end do
-    end do
-
-    call pio_setframe(File,vdesc, t)
-    call pio_read_darray(File, vdesc, iodesc3d, var3d, ierr)
-    cnt=0
-    do k=1,nlev
-       do ie=1,nelemd
-          do j=1,np
-             do i=1,np
-                cnt=cnt+1
-                elem(ie)%state%v(i,j,2,k,tl) = var3d(cnt)
-             end do
-          end do
-       end do
-    end do
-
-    call pio_setframe(File,tdesc, t)
-    call pio_read_darray(File, tdesc, iodesc3d, var3d, ierr)
-    cnt=0
-    do k=1,nlev
-       do ie=1,nelemd
-          do j=1,np
-             do i=1,np
-                cnt=cnt+1
-#ifdef MODEL_THETA_L
-                elem(ie)%state%VTheta_dp(i,j,k,tl) = var3d(cnt)
-#else
-                elem(ie)%state%T(i,j,k,tl) = var3d(cnt)
-#endif
-             end do
-          end do
-       end do
-    end do
-
-#ifdef MODEL_THETA_L
-    if ( theta_hydrostatic_mode ) then
-       do ie=1,nelemd
-          elem(ie)%state%w_i = 0
-          elem(ie)%state%phinh_i = 0
-       end do       
-    else
-       call pio_setframe(File,Wdesc, t)
-       call pio_read_darray(File, Wdesc, iodesc3dp, var3dp, ierr)
-       cnt=0
-       do k=1,nlevp
-          do ie=1,nelemd
-             do j=1,np
-                do i=1,np
-                   cnt=cnt+1
-                   elem(ie)%state%w_i(i,j,k,tl) = var3dp(cnt)
-                end do
-             end do
-          end do
-       end do
-
-       call pio_setframe(File,PHINHdesc, t)
-       call pio_read_darray(File, PHINHdesc, iodesc3dp, var3dp, ierr)
-       cnt=0
-       do k=1,nlevp
-          do ie=1,nelemd
-             do j=1,np
-                do i=1,np
-                   cnt=cnt+1
-                   elem(ie)%state%phinh_i(i,j,k,tl) = var3dp(cnt)
-                end do
-             end do
-          end do
-       end do
-
-    endif
-#endif
-
-    do ie = 1,nelemd
-       elem(ie)%state%Qdp = 0
-    end do
-    do q=1,qsize_d  
-       call pio_setframe(File,qdesc_dp(q), t)
-       call pio_read_darray(File, qdesc_dp(q), iodesc3d, var3d, ierr)
-       cnt=0
-       do k=1,nlev
-          do ie=1,nelemd
-             do j=1,np
-                do i=1,np
-                   cnt=cnt+1
-                   elem(ie)%state%Qdp(i,j,k,q,tlQdp) = var3d(cnt)
-                end do
-             end do
-          end do
-       end do
-
-    end do
-
-    deallocate(var3d,var2d)
-
-#ifdef MODEL_THETA_L
-    if ( .not. theta_hydrostatic_mode )then
-       deallocate(var3dp)
-    endif
-#endif
-
     deallocate(qdesc_dp)
 
-    call t_startf('dyn_init')
-    call dyn_init(dyn_in,dyn_out)
-    call t_stopf('dyn_init')
+   call pio_freedecomp(File, iodesc2d)
+   call pio_freedecomp(File, iodesc3d)
 
-  end subroutine read_restart_dynamics
+end subroutine write_elem
+
+!-------------------------------------------------------------------------------
+
+subroutine write_unstruct()
+
+   ! local variables
+   integer          :: i, ie, ii, j, k
+   integer          :: ierr
+
+   integer :: array_lens_3d(3), array_lens_2d(2)
+   integer :: file_lens_2d(2), file_lens_1d(1)
+
+#ifdef MODEL_THETA_L
+   integer :: array_lens_3dp(3)
+   integer :: file_lens_2dp(2)
+   type(io_desc_t), pointer :: iodescp
+   real(r8),    allocatable :: var3dp(:,:,:)
+#endif
+
+   type(io_desc_t), pointer :: iodesc
+   real(r8),    allocatable :: var2d(:,:), var3d(:,:,:)
+   !----------------------------------------------------------------------------
+
+   grid_id = cam_grid_id('GLL')
+
+   ! write coordinate variables for unstructured GLL grid
+   call cam_grid_write_var(File, grid_id)
+
+   ! create map for distributed write
+   call cam_grid_dimensions(grid_id, grid_dimlens)
+
+   ! create map for distributed write of 2D fields
+   array_lens_2d = (/npsq, nelemd/)
+   file_lens_1d  = (/grid_dimlens(1)/)
+   call cam_grid_get_decomp(grid_id, array_lens_2d, file_lens_1d, pio_double, iodesc)
+
+   allocate(var2d(npsq,nelemd))
+
+   do ie = 1, nelemd
+      ii = 1
+      do j = 1, np
+         do i = 1, np
+            var2d(ii,ie) = elem(ie)%state%ps_v(i,j,tl)
+            ii = ii + 1
+         end do
+      end do
+   end do
+   call PIO_Setframe(File, ps_desc, t_idx)
+   call PIO_Write_Darray(File, ps_desc, iodesc, var2d, ierr)
+
+   do ie = 1, nelemd
+      ii = 1
+      do j = 1, np
+         do i = 1, np
+            var2d(ii,ie) = elem(ie)%state%phis(i,j)
+            ii = ii + 1
+         end do
+      end do
+   end do
+   call PIO_Write_Darray(File, phisdesc, iodesc, var2d, ierr)
+
+   nullify(iodesc)
+   deallocate(var2d)
+
+   ! create map for distributed write of 3D fields
+   array_lens_3d = (/npsq, nlev, nelemd/)
+   file_lens_2d  = (/grid_dimlens(1), nlev/)
+   call cam_grid_get_decomp(grid_id, array_lens_3d, file_lens_2d, pio_double, iodesc)
+
+   allocate(var3d(npsq,nlev,nelemd))
+#ifdef MODEL_THETA_L
+   ! create map for distributed write of 3D nlevp fields
+   array_lens_3dp = (/npsq, nlevp, nelemd/)
+   file_lens_2dp  = (/grid_dimlens(1), nlevp/)
+   call cam_grid_get_decomp(grid_id, array_lens_3dp, file_lens_2dp, pio_double, iodescp)
+   allocate(var3dp(npsq,nlevp,nelemd))
+#endif
+
+   do ie = 1, nelemd
+      do k = 1, nlev
+         ii = 1
+         do j = 1, np
+            do i = 1, np
+               var3d(ii,k,ie) = elem(ie)%derived%omega_p(i,j,k)
+               ii = ii + 1
+            end do
+         end do
+      end do
+   end do
+   call PIO_Write_Darray(File, omegadesc, iodesc, var3d, ierr)
+
+   do ie = 1, nelemd
+      do k = 1, nlev
+         ii = 1
+         do j = 1, np
+            do i = 1, np
+               var3d(ii,k,ie) = elem(ie)%state%V(i,j,1,k,tl)
+               ii = ii + 1
+            end do
+         end do
+      end do
+   end do
+   call PIO_Setframe(File, Udesc, t_idx)
+   call PIO_Write_Darray(File, Udesc, iodesc, var3d, ierr)
+
+   do ie = 1, nelemd
+      do k = 1, nlev
+         ii = 1
+         do j = 1, np
+            do i = 1, np
+               var3d(ii,k,ie) = elem(ie)%state%V(i,j,2,k,tl)
+               ii = ii + 1
+            end do
+         end do
+      end do
+   end do
+   call PIO_Setframe(File, Vdesc, t_idx)
+   call PIO_Write_Darray(File, Vdesc, iodesc, var3d, ierr)
+
+   do ie = 1, nelemd
+      do k = 1, nlev
+         ii = 1
+         do j = 1, np
+            do i = 1, np
+#ifdef MODEL_THETA_L
+               var3d(ii,k,ie) = elem(ie)%state%VTheta_dp(i,j,k,tl)
+#else
+               var3d(ii,k,ie) = elem(ie)%state%T(i,j,k,tl)
+#endif
+               ii = ii + 1
+            end do
+         end do
+      end do
+   end do
+   call PIO_Setframe(File, Tdesc, t_idx)
+   call PIO_Write_Darray(File, Tdesc, iodesc, var3d, ierr)
+
+#ifdef MODEL_THETA_L
+    if( .not. theta_hydrostatic_mode )then
+    ! Write W
+!$omp parallel do private(ie, k, j, i, ii)
+       do ie = 1, nelemd
+          do k = 1, nlevp
+             ii = 1
+             do j = 1, np
+                do i = 1, np
+                   var3dp(ii,k,ie) = elem(ie)%state%w_i(i,j,k,tl)
+                   ii = ii + 1
+                end do
+             end do
+          end do
+       end do
+       call PIO_Setframe(File,Wdesc, t_idx)
+       call PIO_Write_Darray(File,Wdesc,iodescp,var3dp,ierr)
+
+    ! Write Phi
+!$omp parallel do private(ie, k, j, i)
+       do ie=1,nelemd
+          do k=1,nlevp
+             ii = 1
+             do j=1,np
+                do i=1,np
+                   var3dp(ii,k,ie) = elem(ie)%state%phinh_i(i,j,k,tl)
+                   ii = ii + 1
+                end do
+             end do
+          end do
+       end do
+       call PIO_Setframe(File,PHINHdesc, t_idx)
+       call PIO_Write_Darray(File,PHINHdesc,iodescp,var3dp,ierr)
+    endif
+#endif
+   do m = 1, qsize
+
+      !$omp parallel do num_threads(horz_num_threads) private(ie, k, j, i)
+      do ie = 1, nelemd
+         do k = 1, nlev
+            ii = 1
+            do j = 1, np
+               do i = 1, np
+                  var3d(ii,k,ie) = elem(ie)%state%Qdp(i,j,k,m,tlQdp)
+                  ii = ii + 1
+               end do
+            end do
+         end do
+      end do
+      call PIO_Setframe(File, Qdesc_dp(m), t_idx)
+      call PIO_Write_Darray(File, Qdesc_dp(m), iodesc, var3d, ierr)
+
+   end do
+
+   deallocate(var3d)
+   deallocate(qdesc_dp)
+#ifdef MODEL_THETA_L
+   deallocate(var3dp)
+#endif
+end subroutine write_unstruct
+
+!-------------------------------------------------------------------------------
+
+end subroutine write_restart_dynamics
+
+!=========================================================================================
+
+subroutine read_restart_dynamics(File, dyn_in, dyn_out)
+  use control_mod,      only: qsplit
+   ! arguments
+   type(File_desc_t), intent(inout) :: File
+   type(dyn_import_t), intent(out)  :: dyn_in
+   type(dyn_export_t), intent(out)  :: dyn_out
+
+   ! local variables
+   integer(pio_offset_kind), parameter :: t_idx = 1
+
+   integer :: tl, tlQdp
+   integer :: i, ie, ii, k, m, j
+   integer :: ierr, err_handling
+   integer :: fne, fnp, fnlev, fnc
+   integer :: hdim_len, ncols_fvm
+
+   integer :: nlev_dimid
+   integer :: ncol_dimid
+   integer :: ncol_fvm_dimid
+
+   type(var_desc_t) :: phisdesc
+   type(var_desc_t) :: omegadesc
+   type(var_desc_t) :: udesc
+   type(var_desc_t) :: vdesc
+   type(var_desc_t) :: tdesc
+   type(var_desc_t) :: ps_desc
+#ifdef MODEL_THETA_L
+   type(var_desc_t) :: wdesc
+   type(var_desc_t) :: PHINHdesc
+#endif
+
+   type(var_desc_t), allocatable :: qdesc_dp(:)
+
+   integer :: grid_id
+   integer :: grid_dimlens(2)
+   character(len=max_hcoordname_len) :: dimname1, dimname2
+
+   real(r8),    allocatable :: var3d_fvm(:,:,:)
+
+   logical :: readvar
+
+   character(len=*), parameter :: sub = 'read_restart_dynamics'
+   type(element_t),  pointer :: pelem(:)
+   !----------------------------------------------------------------------------
+
+   ! Note1: the hybrid coefficients are read from the same location as for an
+   !        initial run (e.g., dyn_grid_init).
+
+   ! Note2: the dyn_in and dyn_out objects are not associated with the elem and fvm
+   !        objects until dyn_init is called.  Until the restart is better integrated
+   !        into dyn_init we just access elem and fvm directly from the dyn_grid
+   !        module.
+
+   if (iam .lt. par%nprocs) then
+      pelem => elem
+   endif
+
+   tl = timelevel%n0
+   call TimeLevel_Qdp(timelevel, qsplit, tlQdp)
+   call init_nelem_tot()
+
+   call pio_seterrorhandling(File, pio_bcast_error, err_handling)
+
+   ! some checks that the restart contains the same grid as the running model.
+
+   ierr = PIO_Get_Att(File, PIO_GLOBAL, 'ne', fne)
+   ierr = PIO_Get_Att(File, PIO_GLOBAL, 'np', fnp)
+   if (ne /= fne .or. np /= fnp) then
+      write(iulog,*) 'Restart file np or ne does not match model. np (file, model):', &
+                     fnp, np, ' ne (file, model) ', fne, ne
+      call endrun(sub//': Restart file np or ne does not match model.')
+   end if
+
+   ierr = PIO_Inq_DimID(File, 'lev', nlev_dimid)
+   ierr = PIO_Inq_dimlen(File, nlev_dimid, fnlev)
+   if (nlev /= fnlev) then
+      write(iulog,*) 'Restart file nlev does not match model. nlev (file, namelist):', &
+                     fnlev, nlev
+      call endrun(sub//': Restart file nlev does not match model.')
+   end if
+
+   ierr = PIO_Inq_varid(File, 'OMEGA',     omegadesc)
+   call cam_pio_handle_error(ierr, sub//': cannot find OMEGA')
+   ierr = PIO_Inq_varid(File, 'PHIS',     phisdesc)
+   call cam_pio_handle_error(ierr, sub//': cannot find PHIS')
+   ! variable descriptors of required dynamics fields
+   ierr = PIO_Inq_varid(File, 'U',     udesc)
+   call cam_pio_handle_error(ierr, sub//': cannot find U')
+   ierr = PIO_Inq_varid(File, 'V',     Vdesc)
+   call cam_pio_handle_error(ierr, sub//': cannot find V')
+#ifdef MODEL_THETA_L
+   ierr = PIO_Inq_varid(File, 'VTheta_dp',     tdesc)
+   call cam_pio_handle_error(ierr, sub//': cannot find VTheta_dp')
+   ierr = PIO_Inq_varid(File, 'W',     wdesc)
+   call cam_pio_handle_error(ierr, sub//': cannot find W')
+   ierr = PIO_Inq_varid(File, 'PHINH',     PHINHdesc)
+   call cam_pio_handle_error(ierr, sub//': cannot find PHINH')
+#else
+   ierr = PIO_Inq_varid(File, 'T',     tdesc)
+   call cam_pio_handle_error(ierr, sub//': cannot find T')
+#endif
+   ierr = PIO_Inq_varid(File, 'PS', ps_desc)
+   call cam_pio_handle_error(ierr, sub//': cannot find PS')
+
+   allocate(qdesc_dp(qsize))
+   do m = 1, qsize
+      ierr = PIO_Inq_varid(File, "dp"//trim(cnst_name(m)), Qdesc_dp(m))
+      call cam_pio_handle_error(ierr, sub//': cannot find dp'//trim(cnst_name(m)))
+   end do
+
+   ! check whether the restart fields on the GLL grid contain unique columns
+   ! or the element structure (nenpnp = nelem_tot*np*np columns)
+
+   ierr = PIO_Inq_DimID(File, 'nenpnp', ncol_dimid)
+   if (ierr == pio_noerr) then
+
+      call read_elem()
+
+   else
+
+      call read_unstruct()
+
+   end if
+
+   deallocate(qdesc_dp)
+
+   ! recompute dp3d from ps
+   do ie = 1, nelemd
+      do k = 1, nlev
+         elem(ie)%state%dp3d(:,:,k,tl) = ((hyai(k+1) - hyai(k))*ps0) + &
+                              ((hybi(k+1) - hybi(k))*elem(ie)%state%ps_v(:,:,tl))
+      end do
+   end do
+
+   ! Seems like this initialization should be done somewhere else.
+   do ie = 1, nelemd
+      elem(ie)%derived%fM = 0._r8
+      elem(ie)%derived%fT = 0._r8
+      elem(ie)%derived%fQ = 0._r8
+   end do
+
+   ! read cslam fields
+
+   if (ntrac > 0) then
+
+      ! Checks that file and model dimensions agree.
+
+      ierr = PIO_Get_Att(File, PIO_GLOBAL, 'nc', fnc)
+      if (nc /= fnc) then
+         write(iulog,*) 'Restart file nc does not match model. nc (file, model):',fnc,nc,&
+             ' ne (file, model) ', fne, ne
+         call endrun(sub//': Restart file nc does not match model.')
+      end if
+
+      ierr = PIO_Inq_DimID(File, 'ncol_fvm', ncol_fvm_dimid)
+      call cam_pio_handle_error(ierr, sub//': cannot find ncol_fvm')
+      ierr = PIO_Inq_dimlen(File, ncol_fvm_dimid, ncols_fvm)
+
+      grid_id = cam_grid_id('FVM')
+      call cam_grid_dimensions(grid_id, grid_dimlens)
+
+      if (ncols_fvm /= grid_dimlens(1)) then
+         write(iulog,*) 'Restart file ncol_fvm does not match model. ncols_fvm (file, model):',&
+                        ncols_fvm, grid_dimlens(1)
+         call endrun(sub//': Restart file ncols_fvm does not match model.')
+      end if
+
+      allocate(var3d_fvm(nc*nc,nlev,nelemd))
+      var3d_fvm = 0._r8
+
+      ! dp_fvm
+      call infld('dp_fvm', file, 'ncol_fvm', 'lev', 1, nc**2, 1, nlev, 1, nelemd, &
+                 var3d_fvm, readvar, gridname='FVM', timelevel=int(t_idx))
+      do ie = 1, nelemd
+         do k = 1, nlev
+            ii = 1
+            do j = 1, nc
+               do i = 1, nc
+!jt                  fvm(ie)%dp_fvm(i,j,k) = var3d_fvm(ii,k,ie)
+                  ii = ii + 1
+               end do
+            end do
+         end do
+      end do
+
+      ! tracers
+      do m = 1, ntrac
+         call infld(trim(cnst_name(m))//'_fvm', file, 'ncol_fvm', 'lev', &
+                    1, nc**2, 1, nlev, 1, nelemd, var3d_fvm, readvar,    &
+                    gridname='FVM', timelevel=int(t_idx))
+         do ie = 1, nelemd
+            do k = 1, nlev
+               ii = 1
+               do j = 1, nc
+                  do i = 1, nc
+!jt                     fvm(ie)%c(i,j,k,m) = var3d_fvm(ii,k,ie)
+                     ii = ii + 1
+                  end do
+               end do
+            end do
+         end do
+      end do
+
+      ! compute dry surface pressure (a derived quantity)
+      do ie = 1, nelemd
+         do j = 1, nc
+            do i = 1, nc
+!jt               fvm(ie)%psc(i,j) = sum(fvm(ie)%dp_fvm(i,j,:)) +  ptop_ref
+            end do
+         end do
+      end do
+
+   end if
+
+   call pio_seterrorhandling(File, err_handling)
+
+   call dyn_init(dyn_in, dyn_out)
+
+!-------------------------------------------------------------------------------
+contains
+!-------------------------------------------------------------------------------
+
+subroutine read_elem()
+
+   ! local variables
+   integer :: ierr
+   integer :: ncol
+   integer :: i, ie, ii, j, k, m
+
+   integer, pointer :: ldof(:)
+
+   type(io_desc_t) :: iodesc2d, iodesc3d
+   real(r8), allocatable :: var3d(:), var2d(:)
+
+   character(len=*), parameter :: sub='read_elem'
+#ifdef MODEL_THETA_L
+   type(io_desc_t)  :: iodesc3dp
+   real(kind=r8), pointer :: var3dp(:)
+#endif
+   !----------------------------------------------------------------------------
+
+   ierr = PIO_Inq_dimlen(File, ncol_dimid, ncol)
+   call cam_pio_handle_error(ierr, sub//': reading nenpnp')
+
+   ldof => get_restart_decomp(elem, 1)
+   call PIO_InitDecomp(pio_subsystem, pio_double, (/ncol/), ldof, iodesc2d)
+   deallocate(ldof)
+
+   ldof => get_restart_decomp(elem, nlev)
+   call PIO_InitDecomp(pio_subsystem, pio_double, (/ncol,nlev/), ldof, iodesc3d)
+   deallocate(ldof)
+
+#ifdef MODEL_THETA_L
+   ldof => get_restart_decomp(elem, nlevp)
+   call PIO_InitDecomp(pio_subsystem, pio_double, (/ncol,nlevp/), ldof, iodesc3dp)
+   deallocate(ldof)
+#endif
+
+   allocate(var2d(nelemd*np*np), stat=ierr)
+   if (ierr/=0) call endrun( sub//': not able to allocate var2d' )
+   var2d = 0._r8
+
+   call pio_setframe(File, ps_desc, t_idx)
+   call pio_read_darray(File, ps_desc, iodesc2d, var2d, ierr)
+   call cam_pio_handle_error(ierr, sub//': reading PS')
+   ii = 0
+   do ie = 1, nelemd
+      do j = 1, np
+         do i = 1, np
+            ii = ii + 1
+            elem(ie)%state%ps_v(i,j,tl) = var2d(ii)
+         end do
+      end do
+   end do
+
+   var2d = 0._r8
+
+   call pio_read_darray(File, phisdesc, iodesc2d, var2d, ierr)
+   call cam_pio_handle_error(ierr, sub//': reading PHIS')
+   ii = 0
+   do ie = 1, nelemd
+      do j = 1, np
+         do i = 1, np
+            ii = ii + 1
+            elem(ie)%state%phis(i,j) = var2d(ii)
+         end do
+      end do
+   end do
+
+   deallocate(var2d)
+   allocate(var3d(nelemd*np*np*nlev), stat=ierr)
+   if (ierr/=0) call endrun( sub//': not able to allocate var3d' )
+
+   var3d = 0._r8
+   call pio_read_darray(File, omegadesc, iodesc3d, var3d, ierr)
+   call cam_pio_handle_error(ierr, sub//': reading OMEGA')
+   ii = 0
+   do k = 1, nlev
+      do ie = 1, nelemd
+         do j = 1, np
+            do i = 1, np
+               ii = ii + 1
+               elem(ie)%derived%omega_p(i,j,k) = var3d(ii)
+            end do
+         end do
+      end do
+   end do
+
+   var3d = 0._r8
+
+   call pio_setframe(File, udesc, t_idx)
+   call pio_read_darray(File, udesc, iodesc3d, var3d, ierr)
+   call cam_pio_handle_error(ierr, sub//': reading U')
+   ii = 0
+   do k = 1, nlev
+      do ie = 1, nelemd
+         do j = 1, np
+            do i = 1, np
+               ii = ii + 1
+               elem(ie)%state%v(i,j,1,k,tl) = var3d(ii)
+            end do
+         end do
+      end do
+   end do
+
+   call pio_setframe(File, vdesc, t_idx)
+   call pio_read_darray(File, vdesc, iodesc3d, var3d, ierr)
+   call cam_pio_handle_error(ierr, sub//': reading V')
+   ii = 0
+   do k = 1, nlev
+      do ie = 1, nelemd
+         do j = 1, np
+            do i = 1, np
+               ii = ii + 1
+               elem(ie)%state%v(i,j,2,k,tl) = var3d(ii)
+            end do
+         end do
+      end do
+   end do
+
+   call pio_setframe(File, tdesc, t_idx)
+   call pio_read_darray(File, tdesc, iodesc3d, var3d, ierr)
+   call cam_pio_handle_error(ierr, sub//': reading T')
+   ii = 0
+   do k = 1, nlev
+      do ie = 1, nelemd
+         do j = 1, np
+            do i = 1, np
+               ii = ii + 1
+#ifdef MODEL_THETA_L
+               elem(ie)%state%VTheta_dp(i,j,k,tl) = var3d(ii)
+#else
+               elem(ie)%state%T(i,j,k,tl) = var3d(ii)
+#endif
+            end do
+         end do
+      end do
+   end do
+
+#ifdef MODEL_THETA_L
+   allocate(var3dp(nelemd*np*np*nlevp), stat=ierr)
+   if (ierr/=0) call endrun( sub//': not able to allocate var3dp' )
+
+   var3dp = 0._r8
+   call pio_setframe(File, wdesc, t_idx)
+   call pio_read_darray(File, wdesc, iodesc3dp, var3dp, ierr)
+   call cam_pio_handle_error(ierr, sub//': reading W')
+   ii = 0
+   do k = 1, nlev
+      do ie = 1, nelemd
+         do j = 1, np
+            do i = 1, np
+               ii = ii + 1
+               elem(ie)%state%w_i(i,j,k,tl) = var3dp(ii)
+            end do
+         end do
+      end do
+   end do
+
+   var3dp = 0._r8
+   call pio_setframe(File, phinhdesc, t_idx)
+   call pio_read_darray(File, phinhdesc, iodesc3dp, var3dp, ierr)
+   call cam_pio_handle_error(ierr, sub//': reading PHINH')
+   ii = 0
+   do k = 1, nlev
+      do ie = 1, nelemd
+         do j = 1, np
+            do i = 1, np
+               ii = ii + 1
+               elem(ie)%state%phinh_i(i,j,k,tl) = var3dp(ii)
+            end do
+         end do
+      end do
+   end do
+   deallocate(var3dp)
+#endif
+
+   do m = 1, qsize
+      call pio_setframe(File, qdesc_dp(m), t_idx)
+      call pio_read_darray(File, qdesc_dp(m), iodesc3d, var3d, ierr)
+      call cam_pio_handle_error(ierr, sub//': reading dp'//trim(cnst_name(m)))
+      ii = 0
+      do k = 1, nlev
+         do ie = 1, nelemd
+            do j = 1, np
+               do i = 1, np
+                  ii = ii + 1
+                  elem(ie)%state%Qdp(i,j,k,m,tlQdp) = var3d(ii)
+               end do
+            end do
+         end do
+      end do
+   end do
+
+   deallocate(var3d)
+
+   if (masterproc) write(iulog,*) sub//': completed successfully'
+
+end subroutine read_elem
+
+!-------------------------------------------------------------------------------
+
+subroutine read_unstruct()
+
+   ! local variables
+   integer :: grid_id
+
+   integer :: i, ie, ii, j, kptr, m, nlev_tot
+
+   real(r8), allocatable :: dbuf2(:,:)         ! (npsq,nelemd)
+   real(r8), allocatable :: dbuf3(:,:,:)       ! (npsq,nlev,nelemd)
+   real(r8), allocatable :: dbuf3p(:,:,:)       ! (npsq,nlev,nelemd)
+
+   character(len=*), parameter :: sub='read_unstruct'
+   !----------------------------------------------------------------------------
+
+   ! The name of the unstructured grid dimension is in the grid object
+   ! since the coordinate date was written to the restart file using
+   ! that object.
+   grid_id = cam_grid_id('GLL')
+   call cam_grid_get_dim_names(grid_id, dimname1, dimname2)
+
+   allocate(dbuf2(npsq,nelemd))
+
+   call read_2d('PS', dbuf2)
+   do ie = 1, nelemd
+      ii = 1
+      do j = 1, np
+         do i = 1, np
+            elem(ie)%state%ps_v(i,j,tl) = dbuf2(ii,ie)
+            ii = ii + 1
+         end do
+      end do
+   end do
+
+   call read_2d('PHIS', dbuf2)
+   do ie = 1, nelemd
+      ii = 1
+      do j = 1, np
+         do i = 1, np
+            elem(ie)%state%phis(i,j) = dbuf2(ii,ie)
+            ii = ii + 1
+         end do
+      end do
+   end do
+
+   deallocate(dbuf2)
+
+   allocate(dbuf3(npsq,nlev,nelemd))
+
+   call read_3d('OMEGA', dbuf3)
+   do ie = 1, nelemd
+      ii = 1
+      do j = 1, np
+         do i = 1, np
+            elem(ie)%derived%omega_p(i,j,:) = dbuf3(ii,:,ie)
+            ii = ii + 1
+         end do
+      end do
+   end do
+
+   call read_3d('U', dbuf3)
+   do ie = 1, nelemd
+      ii = 1
+      do j = 1, np
+         do i = 1, np
+            elem(ie)%state%v(i,j,1,:,tl) = dbuf3(ii,:,ie)
+            ii = ii + 1
+         end do
+      end do
+   end do
+
+   call read_3d('V', dbuf3)
+   do ie = 1, nelemd
+      ii = 1
+      do j = 1, np
+         do i = 1, np
+            elem(ie)%state%v(i,j,2,:,tl) = dbuf3(ii,:,ie)
+            ii = ii + 1
+         end do
+      end do
+   end do
+
+#ifdef MODEL_THETA_L
+   call read_3d('T', dbuf3)
+#else
+   call read_3d('VTheta_dp', dbuf3)
+#endif
+   do ie = 1, nelemd
+      ii = 1
+      do j = 1, np
+         do i = 1, np
+#ifdef MODEL_THETA_L
+            elem(ie)%state%VTheta_dp(i,j,:,tl) = dbuf3(ii,:,ie)
+#else
+            elem(ie)%state%T(i,j,:,tl) = dbuf3(ii,:,ie)
+#endif
+            ii = ii + 1
+         end do
+      end do
+   end do
+
+#ifdef MODEL_THETA_L
+
+   allocate(dbuf3p(npsq,nlevp,nelemd))
+
+   call read_3dp('W', dbuf3p)
+   do ie = 1, nelemd
+      ii = 1
+      do j = 1, np
+         do i = 1, np
+            elem(ie)%state%w_i(i,j,:,tl) = dbuf3p(ii,:,ie)
+            ii = ii + 1
+         end do
+      end do
+   end do
+
+   call read_3dp('PHINH', dbuf3p)
+   do ie = 1, nelemd
+      ii = 1
+      do j = 1, np
+         do i = 1, np
+            elem(ie)%state%phinh_i(i,j,:,tl) = dbuf3p(ii,:,ie)
+            ii = ii + 1
+         end do
+      end do
+   end do
+
+   deallocate(dbuf3p)
+
+#endif
+   do m = 1, qsize
+
+      call read_3d('dp'//trim(cnst_name(m)), dbuf3)
+      do ie = 1, nelemd
+         ii = 1
+         do j = 1, np
+            do i = 1, np
+               elem(ie)%state%Qdp(i,j,:,m,tlQdp) = dbuf3(ii,:,ie)
+               ii = ii + 1
+            end do
+         end do
+      end do
+
+   end do
+
+   deallocate(dbuf3)
+
+   ! boundary exchange
+   nlev_tot=2+(4+pcnst)*nlev+2*nlevp
+
+   do ie = 1, nelemd
+      kptr = 0
+      call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%ps_v(:,:,tl), 1, kptr, nlev_tot)
+      kptr = kptr + 1
+      call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%phis(:,:), 1, kptr, nlev_tot)
+      kptr = kptr + 1
+      call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%derived%omega_p(:,:,:), nlev, kptr, nlev_tot)
+      kptr = kptr + nlev
+      call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%v(:,:,:,:,tl), 2*nlev, kptr, nlev_tot)
+      kptr = kptr + (2 * nlev)
+#ifdef MODEL_THETA_L
+      call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%VTheta_dp(:,:,:,tl), nlev, kptr, nlev_tot)
+#else
+      call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%T(:,:,:,tl), nlev, kptr, nlev_tot)
+#endif
+      kptr = kptr + nlev
+#ifdef MODEL_THETA_L
+      call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%w_i(:,:,:,tl), nlevp, kptr, nlev_tot)
+      kptr = kptr + nlevp
+      call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%phinh_i(:,:,:,tl), nlevp, kptr, nlev_tot)
+      kptr = kptr + nlevp
+#endif
+      call edgeVpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%Qdp(:,:,:,:,tlQdp), nlev*qsize, kptr, nlev_tot)
+   end do
+   if (iam < par%nprocs) then
+      call bndry_exchangeV(par, edge_g)
+   end if
+   do ie = 1, nelemd
+      kptr = 0
+      call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%ps_v(:,:,tl), 1, kptr, nlev_tot)
+      kptr = kptr + 1
+      call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%phis(:,:), 1, kptr, nlev_tot)
+      kptr = kptr + 1
+      call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%derived%omega_p(:,:,:), nlev, kptr, nlev_tot)
+      kptr = kptr + nlev
+      call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%v(:,:,:,:,tl), 2*nlev, kptr, nlev_tot)
+      kptr = kptr + (2 * nlev)
+#ifdef MODEL_THETA_L
+      call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%VTheta_dp(:,:,:,tl), nlev, kptr, nlev_tot)
+#else
+      call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%T(:,:,:,tl), nlev, kptr, nlev_tot)
+#endif
+      kptr = kptr + nlev
+#ifdef MODEL_THETA_L
+      call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%w_i(:,:,:,tl), nlevp, kptr, nlev_tot)
+      kptr = kptr + nlevp
+      call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%phinh_i(:,:,:,tl), nlevp, kptr, nlev_tot)
+      kptr = kptr + nlevp
+#endif
+      call edgeVunpack_nlyr(edge_g, elem(ie)%desc, elem(ie)%state%Qdp(:,:,:,:,tlQdp), nlev*qsize, kptr, nlev_tot)
+   end do
+end subroutine read_unstruct
+
+!-------------------------------------------------------------------------------
+
+subroutine read_2d(fieldname, buffer)
+
+   character(len=*),  intent(in)    :: fieldname
+   real(r8),          intent(inout) :: buffer(:, :)
+
+   logical :: found
+   !----------------------------------------------------------------------------
+
+   buffer = 0.0_r8
+   call infld(trim(fieldname), file, dimname1, 1, npsq, 1, nelemd, buffer, &
+              found, gridname='GLL', timelevel=int(t_idx))
+   if (.not. found) then
+      call endrun('read_restart_dynamics: read_unstruct: read_2d: Could not find ' // &
+                   trim(fieldname))
+   end if
+
+   ! This code allows use of compiler option to set uninitialized values
+   ! to NaN.  In that case infld can return NaNs where the element GLL points
+   ! are not "unique columns"
+   where (isnan(buffer)) buffer = 0.0_r8
+
+end subroutine read_2d
+
+!-------------------------------------------------------------------------------
+
+subroutine read_3d(fieldname, buffer)
+
+   character(len=*),  intent(in)    :: fieldname
+   real(r8),          intent(inout) :: buffer(:,:,:)
+
+   logical :: found
+   !----------------------------------------------------------------------------
+
+   buffer = 0.0_r8
+   call infld(trim(fieldname), file, dimname1, 'lev', 1, npsq, 1, nlev, &
+              1, nelemd, buffer, found, gridname='GLL', timelevel=int(t_idx))
+   if (.not. found) then
+      call endrun('read_restart_dynamics: read_unstruct: read_3d: Could not find ' // &
+                   trim(fieldname))
+   end if
+
+   ! This code allows use of compiler option to set uninitialized values
+   ! to NaN.  In that case infld can return NaNs where the element GLL points
+   ! are not "unique columns"
+   where (isnan(buffer)) buffer = 0.0_r8
+
+end subroutine read_3d
+
+!-------------------------------------------------------------------------------
+subroutine read_3dp(fieldname, buffer)
+
+   character(len=*),  intent(in)    :: fieldname
+   real(r8),          intent(inout) :: buffer(:,:,:)
+
+   logical :: found
+   !----------------------------------------------------------------------------
+
+   buffer = 0.0_r8
+   call infld(trim(fieldname), file, dimname1, 'ilev', 1, npsq, 1, nlevp, &
+              1, nelemd, buffer, found, gridname='GLL', timelevel=int(t_idx))
+   if (.not. found) then
+      call endrun('read_restart_dynamics: read_unstruct: read_3dp: Could not find ' // &
+                   trim(fieldname))
+   end if
+
+   ! This code allows use of compiler option to set uninitialized values
+   ! to NaN.  In that case infld can return NaNs where the element GLL points
+   ! are not "unique columns"
+   where (isnan(buffer)) buffer = 0.0_r8
+
+ end subroutine read_3dp
+
+!-------------------------------------------------------------------------------
+end subroutine read_restart_dynamics
+
+!=========================================================================================
+! Private
+!=========================================================================================
+
+function get_restart_decomp(elem, lev) result(ldof)
+
+   ! Get the integer mapping of a variable in the dynamics decomp in memory.
+   ! The canonical ordering is as on the file. A 0 value indicates that the
+   ! variable is not on the file (eg halo or boundary values)
+
+   type(element_t), intent(in) :: elem(:)
+   integer,         intent(in) :: lev
+   integer,         pointer    :: ldof(:)
+
+   integer :: i, j, k, ie
+   !----------------------------------------------------------------------------
+
+   allocate(ldof(nelemd*np*np*lev))
+
+   j = 1
+   do k = 1, lev
+      do ie = 1, nelemd
+         do i = 1, np*np
+            ldof(j) = (elem(ie)%GlobalID-1)*np*np + (k-1)*nelem_tot*np*np + i
+            j = j + 1
+         end do
+      end do
+   end do
+
+end function get_restart_decomp
+
+!=========================================================================================
+
+function get_restart_decomp_fvm(elem, lev) result(ldof)
+
+   type(element_t), intent(in) :: elem(:)
+   integer,         intent(in) :: lev
+   integer,         pointer    :: ldof(:)
+
+   integer :: i, j, k, ie
+   !----------------------------------------------------------------------------
+
+   allocate(ldof(nelemd*nc*nc*lev))
+
+   j = 1
+   do k = 1, lev
+      do ie = 1, nelemd
+         do i = 1, nc*nc
+            ldof(j) = (elem(ie)%GlobalID-1)*nc*nc + (k-1)*nelem_tot*nc*nc + i
+            j = j + 1
+         end do
+      end do
+   end do
+
+end function get_restart_decomp_fvm
+
+!=========================================================================================
 
 end module restart_dynamics


### PR DESCRIPTION
replaced restart_dynamics with a slightly modified version of CAM's version instead of E3SM version and move setting of use_moisture to dyn_init so it is set properly on init and restart runs.

The following now works on Izumi.

./create_test ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal

Here is the test case status
[jet@i015 scripts]$ /scratch/cluster/jet/cs.status.20250212_153659_ck21kj
20250212_153659_ck21kj: 1 test
  ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal (Overall: PASS) details:
    PASS ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal CREATE_NEWCASE
    PASS ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal XML
    PASS ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal SETUP
    PASS ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal SHAREDLIB_BUILD time=73
    PASS ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal MODEL_BUILD time=125
    PASS ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal SUBMIT
    PASS ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal RUN time=149
    PASS ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal COMPARE_base_rest
    PASS ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal MEMLEAK insuffiencient data for memleak test
    PASS ERS_Ln27_Vmct.ne16_g17.FKESSLER.izumi_gnu.cam-outfrq9s_thetal SHORT_TERM_ARCHIVER
