### PR TITLE
Fix broken tests on Derecho

### DIFF
--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_thetal/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_thetal/shell_commands
@@ -1,4 +1,3 @@
 ./xmlchange ROF_NCPL=\$ATM_NCPL
 ./xmlchange GLC_NCPL=\$ATM_NCPL
 ./xmlchange CAM_TARGET=theta-l
-./xmlchange PROJECT=none


### PR DESCRIPTION
On Derecho, running a test requires a valid value of `PROJECT` account. Setting it to `none` will fail to launch the job on a compute node.

We can do something like below instead on Derecho:
```
./create_test ERS_Ln27_Vmct.ne16_g17.FKESSLER.derecho_intel.cam-outfrq9s_thetal -p ${PROJECT_ACCOUNT}
```