### PR TITLE
Add a CI workflow to build StormSPEED with a docker image

### DIFF
--- a/.github/workflows/docker_workflow.yml
+++ b/.github/workflows/docker_workflow.yml
@@ -1,0 +1,31 @@
+name: Docker container to build StormSPEED CAM
+
+on:
+  push:
+    branches:
+      - stormspeed
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  docker-build-and-test:
+    name: Build and Test - ${{ matrix.dockerfile }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        dockerfile:
+          - Dockerfile.gnu
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build Docker image which will compile a predefined compset for StormSPEED CAM
+        run: docker build -t stormspeed_pr -f dockerfiles/${{ matrix.dockerfile }} .

--- a/.gitmodules
+++ b/.gitmodules
@@ -144,7 +144,7 @@ fxDONOTUSEurl = https://github.com/ESCOMP/mizuRoute
 [submodule "ccs_config"]
 path = ccs_config
 url = https://github.com/sjsprecious/ccs_config_cesm.git
-fxtag = 95e14581
+fxtag = 7fa8332f
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/sjsprecious/ccs_config_cesm.git 
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -143,10 +143,10 @@ fxDONOTUSEurl = https://github.com/ESCOMP/mizuRoute
 
 [submodule "ccs_config"]
 path = ccs_config
-url = https://github.com/jtruesdal/ccs_config_cesm.git 
-fxtag = ccs_config_cesm1.0.40_nh.02
+url = https://github.com/sjsprecious/ccs_config_cesm.git
+fxtag = 95e14581
 fxrequired = ToplevelRequired
-fxDONOTUSEurl = https://github.com/jtruesdal/ccs_config_cesm.git 
+fxDONOTUSEurl = https://github.com/sjsprecious/ccs_config_cesm.git 
 
 [submodule "cime"]
 path = cime

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -330,8 +330,16 @@ def _build_cam(caseroot, libroot, bldroot):
                 slr = os.path.abspath(case.get_value("SHAREDLIBROOT"))
                 kokkosbuildroot = os.path.join(slr, sharedpath)
 
+                libdir = None
+                if os.path.isdir(os.path.join(kokkosbuildroot, "lib64")):
+                    libdir = os.path.join(kokkosbuildroot, "lib64")
+                elif os.path.isdir(os.path.join(kokkosbuildroot, "lib")):
+                    libdir = os.path.join(kokkosbuildroot, "lib")
+                else:
+                    expect(False, f"No lib or lib64 directory found in {kokkosbuildroot}")
+
                 for libs in ["libkokkoscontainers.a", "libkokkoscore.a", "libkokkossimd.a"]:
-                    libkokkos = os.path.join(kokkosbuildroot, "lib64", libs)
+                    libkokkos = os.path.join(libdir, libs)
                     if os.path.isfile(libkokkos):
                         shutil.copy(libkokkos, libroot)
                     else:

--- a/dockerfiles/Dockerfile.gnu
+++ b/dockerfiles/Dockerfile.gnu
@@ -1,0 +1,37 @@
+# versions and sizes from here: https://hub.docker.com/r/jiansunncar/ubuntu24.04_gcc12.4.0_stormspeed
+FROM jiansunncar/ubuntu24.04_gcc12.4.0_stormspeed:v0
+
+# Copy the source code from a pull request into the container
+COPY . /tmp/StormSPEED
+
+# Set up some git configurations; it can be any user name and email address
+RUN git config --global user.email "example_user@example.com" \
+    && git config --global user.name "example_user"
+
+# Check out individual components of StormSPEED
+RUN cd /tmp/StormSPEED \
+    && ./bin/git-fleximod update
+
+# Set up some case-independent environment variables
+ENV TMP=tmp
+ENV USER=example_user
+
+# build an FADIAB test at 1-degree resolution
+RUN . /home/spack/share/spack/setup-env.sh \
+    && spack load gcc@12.4.0 libxml2 cmake openmpi netcdf-c netcdf-fortran parallel-netcdf parallelio esmf \
+    && export MPI_ROOT=$(spack location -i openmpi@5.0.8 ^gcc@12.4.0) \
+    && export NETCDF_C_PATH=$(spack location -i netcdf-c@4.9.2) \
+    && export NETCDF_FORTRAN_PATH=$(spack location -i netcdf-fortran@4.6.1) \
+    && export PNETCDF=$(spack location -i parallel-netcdf@1.14.0) \
+    && export PIO=$(spack location -i parallelio@2.6.5) \
+    && export ESMFMKFILE=$(spack location -i esmf@8.8.1)/lib/esmf.mk \
+    && export LAPACK=$(spack location -i netlib-lapack@3.12.1) \
+    && export PIO_VERSION_MAJOR=2 \
+    && export PIO_TYPENAME_VALID_VALUES="netcdf, pnetcdf, netcdf4c, netcdf4p" \
+    && cd /tmp/StormSPEED/cime/scripts \
+    && ./create_newcase --case /$TMP/ci_test --machine cirrus --compset FADIAB --res ne30_ne30_mg17 --compiler gnu --run-unsupported \
+    && cd /$TMP/ci_test \
+    && ./case.setup \
+    && ./case.build
+
+WORKDIR /$TMP/ci_test


### PR DESCRIPTION
This pull request will add a CI workflow which:
- pulls a docker image that contains all the software stacks to build a StormSPEED test
- builds the revised code from a future pull request and checks if it succeeds

Currently this docker image contains the GNU compiler and works only on the CPUs. It also does not run the executable yet and it will be performed on the CISL CIRRUS cloud service in the next pull request.