### PR TITLE
Save CI workflow output to CIRRUS storage

### DIFF
--- a/.github/workflows/build_and_run_workflow.yml
+++ b/.github/workflows/build_and_run_workflow.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Build and run on CIRRUS
 
 on:
   push:
@@ -13,7 +13,15 @@ concurrency:
 
 jobs:
   build-and-run-on-CIRRUS:
-    name: Build and run ${{ matrix.image }} on ${{ matrix.runner }}
+    name: Run ${{ matrix.image }} on ${{ matrix.runner }}
+    env:
+      TMP_DIR: tmp
+      TMP_OUTPUT: case_output.log
+      GENERATE_BASELINE: true
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     strategy:
       fail-fast: false
       matrix:
@@ -21,32 +29,32 @@ jobs:
         res: [ ne30_ne30_mg17 ]
         dycore: [ theta-l, theta-l_kokkos ]
         image: [
-          opensuse15:gcc12_openmpi5.0.8_cpu,
-          almalinux9.6:intel2024_openmpi5.0.8_cpu,
-          ubuntu24.04:nvhpc25.7_openmpi4.1.5_cpu,
-          opensuse15:gcc12_openmpi5.0.8_cuda12.9,
-          ubuntu24.04:nvhpc25.7_openmpi5.0.8_cuda12.9
+          opensuse15_gcc12_openmpi5.0.8_cpu:bd1e777,
+          opensuse15_gcc12_openmpi5.0.8_cuda12.9:bd1e777,
+          almalinux9.6_intel2024_openmpi5.0.8_cpu:bd1e777,
+          ubuntu24.04_nvhpc25.7_openmpi4.1.5_cpu:bd1e777,
+          ubuntu24.04_nvhpc25.7_openmpi5.0.8_cuda12.9:bd1e777
         ]
         include:
-          - image: opensuse15:gcc12_openmpi5.0.8_cpu
+          - image: opensuse15_gcc12_openmpi5.0.8_cpu:bd1e777
             runner: gha-runner-stormspeed
             compiler: gnu
-          - image: almalinux9.6:intel2024_openmpi5.0.8_cpu
+          - image: almalinux9.6_intel2024_openmpi5.0.8_cpu:bd1e777
             runner: gha-runner-stormspeed
             compiler: intel
-          - image: ubuntu24.04:nvhpc25.7_openmpi4.1.5_cpu
+          - image: ubuntu24.04_nvhpc25.7_openmpi4.1.5_cpu:bd1e777
             runner: gha-runner-stormspeed
             compiler: nvhpc
-          - image: opensuse15:gcc12_openmpi5.0.8_cuda12.9
+          - image: opensuse15_gcc12_openmpi5.0.8_cuda12.9:bd1e777
             runner: gha-runner-gpu-stormspeed
             compiler: gnu
-          - image: ubuntu24.04:nvhpc25.7_openmpi5.0.8_cuda12.9
+          - image: ubuntu24.04_nvhpc25.7_openmpi5.0.8_cuda12.9:bd1e777
             runner: gha-runner-gpu-stormspeed
             compiler: nvhpc
         exclude:
-          - image: opensuse15:gcc12_openmpi5.0.8_cuda12.9
+          - image: opensuse15_gcc12_openmpi5.0.8_cuda12.9:bd1e777
             dycore: theta-l
-          - image: ubuntu24.04:nvhpc25.7_openmpi5.0.8_cuda12.9
+          - image: ubuntu24.04_nvhpc25.7_openmpi5.0.8_cuda12.9:bd1e777
             dycore: theta-l
     runs-on: ${{ matrix.runner }}
     container:
@@ -56,57 +64,35 @@ jobs:
       credentials:
         username: ${{ secrets.hub_user }}
         password: ${{ secrets.hub_password }}
-    env:
-      TMP_DIR: tmp
-      TMP_OUTPUT: case_output.log
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout code from a pull request or push
         uses: actions/checkout@v4
 
-      - name: Set up some git configurations; it can be any user name and email address
+      - name: Set up some git configurations
         run: |
+          # it can be any user name and email address
           git config --global user.email "example_user@example.com"
           git config --global user.name "example_user"
 
       - name: Checkout individual components
-        run: | # Use -C option to specify the workspace directory; otherwise root_dir is set to '.' and the checkout will fail
-          . /opt/spack/share/spack/setup-env.sh && \
-          spack load python && \
+        run: |
+          # Use -C option to specify the workspace directory; otherwise root_dir is set to '.' and the checkout will fail
           ./bin/git-fleximod -C ${GITHUB_WORKSPACE} update
 
-      - name: Build and run ${{ matrix.compset }} with ${{ matrix.dycore }} at ${{ matrix.res }} resolution on CIRRUS CPU
-        if: matrix.runner == 'gha-runner-stormspeed'
+      - name: Create ${{ matrix.compset }} with ${{ matrix.dycore }} at ${{ matrix.res }} resolution
         run: |
-          ################################
-          # Set up environment variables #
-          ################################
-          . /opt/spack/share/spack/setup-env.sh
-          spack load python libxml2 openmpi parallel-netcdf parallelio esmf
-          if ! command -v cmake &> /dev/null; then
-            spack load cmake
-          fi
-          # the NVHPC CPU image comes with openmpi/4.1.5, so we don't install openmpi with Spack and set MPI_ROOT inside the image directly
-          if [ "${{ matrix.compiler }}" != "nvhpc" ]; then
-            export MPI_ROOT=$(spack location -i openmpi@5.0.8)
-          fi
-          if [ "${{ matrix.compiler }}" == "intel" ]; then
-            spack load intel-oneapi-mkl@2024.2.2
-          fi
-          export NETCDF_C_PATH=$(spack location -i netcdf-c@4.9.2)
-          export NETCDF_FORTRAN_PATH=$(spack location -i netcdf-fortran@4.6.1)
-          export PNETCDF=$(spack location -i parallel-netcdf@1.14.0)
-          export PIO=$(spack location -i parallelio@2.6.6)
-          export ESMFMKFILE=$(spack location -i esmf@8.8.1)/lib/esmf.mk
-          export LAPACK=$(spack location -i netlib-lapack@3.12.1)
-          export PIO_VERSION_MAJOR=2
-          export PIO_TYPENAME_VALID_VALUES="netcdf, pnetcdf, netcdf4c, netcdf4p"
-          export USER=robot
           #####################
           # Create a new case #
           #####################
           cd cime/scripts
           ./create_newcase --case /$TMP_DIR/ci_test --machine cirrus --compset ${{ matrix.compset }} \
             --res ${{ matrix.res }} --compiler ${{ matrix.compiler }} --run-unsupported
+
+      - name: Build
+        run: |
           ############################
           # Customize configurations #
           ############################
@@ -115,18 +101,29 @@ jobs:
           ./xmlchange CAM_TARGET=${{ matrix.dycore }}
           ./xmlchange STOP_OPTION=ndays,STOP_N=1,RESUBMIT=0
           ./xmlchange DOUT_S='FALSE'
+          if [ "${{ matrix.runner }}" == "gha-runner-gpu-stormspeed" ]; then
+            ./xmlchange GPU_TYPE=a10
+            ./xmlchange KOKKOS_GPU_OFFLOAD=TRUE
+            ./xmlchange OVERSUBSCRIBE_GPU=FALSE
+          fi
           ./case.setup
           #########
           # Build #
           #########
           ./case.build
-          ##########################
-          # Turn off I/O for a run #
-          ##########################
+
+      - name: Run
+        run: |
+          ########################
+          # Output daily average #
+          ########################
+          cd /$TMP_DIR/ci_test
           cat <<EOF > user_nl_cam
           se_statefreq = 488,
-          empty_htapes = .true.,
-          fincl1 = '',
+          mfilt=1,
+          ndens=1,
+          nhtfrq=-24,
+          inithist='ENDOFRUN'
           /
           EOF
           cat <<EOF > user_nl_cice
@@ -137,96 +134,32 @@ jobs:
           ################
           # Run the test #
           ################
-          if [ -d "$LAPACK/lib64" ]; then
-            export LAPACK_LIBDIR="$LAPACK/lib64"
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PIO/lib:$NETCDF_FORTRAN_PATH/lib:$NETCDF_C_PATH/lib:$LAPACK/lib:$LAPACK/lib64:$PNETCDF/lib
+          if [ "${{ matrix.runner }}" == "gha-runner-gpu-stormspeed" ]; then
+            export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CUDA_ROOT/lib64:$CUDA_ROOT/lib64/stubs
           else
-            export LAPACK_LIBDIR="$LAPACK/lib"
+            export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$MKLROOT/lib
           fi
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PIO/lib:$NETCDF_FORTRAN_PATH/lib:$NETCDF_C_PATH/lib:$LAPACK_LIBDIR:$PNETCDF/lib
           ./case.submit --no-batch 2>&1 | tee "$TMP_OUTPUT"
-          ################
-          # Pass or fail #
-          ################    
+      
+      - name: Check the test PASS/FAIL status
+        if: always()
+        run: |
+          cd /$TMP_DIR/ci_test
           # Check the last 5 lines for 'failed' or 'error:' (case-insensitive)
           if tail -n 5 "$TMP_OUTPUT" | grep -iE 'failed|error:'; then
+            echo "Test failed"
             exit 911
+          else
+            echo "Test passed"
           fi
 
-      - name: Build and run ${{ matrix.compset }} with ${{ matrix.dycore }} at ${{ matrix.res }} resolution on CIRRUS GPU
-        if: matrix.runner == 'gha-runner-gpu-stormspeed' && matrix.dycore == 'theta-l_kokkos'
+      - name: Upload the netCDF output files to CIRRUS storage
+        if: env.GENERATE_BASELINE == 'true'
         run: |
-          ################################
-          # Set up environment variables #
-          ################################
-          . /opt/spack/share/spack/setup-env.sh
-          spack load python libxml2 openmpi parallel-netcdf parallelio esmf
-          if ! command -v cmake &> /dev/null; then
-            spack load cmake
-          fi
-          export MPI_ROOT=$(spack location -i openmpi@5.0.8)
-          export NETCDF_C_PATH=$(spack location -i netcdf-c@4.9.2)
-          export NETCDF_FORTRAN_PATH=$(spack location -i netcdf-fortran@4.6.1)
-          export PNETCDF=$(spack location -i parallel-netcdf@1.14.0)
-          export PIO=$(spack location -i parallelio@2.6.6)
-          export ESMFMKFILE=$(spack location -i esmf@8.8.1)/lib/esmf.mk
-          export LAPACK=$(spack location -i netlib-lapack@3.12.1)
-          if [ "${{ matrix.compiler }}" != "nvhpc" ]; then
-            spack load cuda
-            export CUDA_ROOT=$(spack location -i cuda@12.9.0)
-          fi
-          export PIO_VERSION_MAJOR=2
-          export PIO_TYPENAME_VALID_VALUES="netcdf, pnetcdf, netcdf4c, netcdf4p"
-          export USER=robot
-          #####################
-          # Create a new case #
-          #####################
-          cd cime/scripts
-          ./create_newcase --case /$TMP_DIR/ci_test --machine cirrus --compset ${{ matrix.compset }} \
-            --res ${{ matrix.res }} --compiler ${{ matrix.compiler }} --run-unsupported
-          ############################
-          # Customize configurations #
-          ############################
-          cd /$TMP_DIR/ci_test
-          ./xmlchange NTASKS=16
-          ./xmlchange CAM_TARGET=${{ matrix.dycore }}
-          ./xmlchange GPU_TYPE=a10
-          ./xmlchange KOKKOS_GPU_OFFLOAD=TRUE
-          ./xmlchange OVERSUBSCRIBE_GPU=FALSE
-          ./xmlchange STOP_OPTION=ndays,STOP_N=1,RESUBMIT=0
-          ./xmlchange DOUT_S='FALSE'
-          ./case.setup
-          #########
-          # Build #
-          #########
-          ./case.build
-          ##########################
-          # Turn off I/O for a run #
-          ##########################
-          cat <<EOF > user_nl_cam
-          se_statefreq = 488,
-          empty_htapes = .true.,
-          fincl1 = '',
-          /
-          EOF
-          cat <<EOF > user_nl_cice
-          empty_htapes = .true.,
-          fincl1 = '',
-          /
-          EOF
-          ################
-          # Run the test #
-          ################
-          if [ -d "$LAPACK/lib64" ]; then
-            export LAPACK_LIBDIR="$LAPACK/lib64"
-          else
-            export LAPACK_LIBDIR="$LAPACK/lib"
-          fi
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PIO/lib:$NETCDF_FORTRAN_PATH/lib:$NETCDF_C_PATH/lib:$LAPACK_LIBDIR:$PNETCDF/lib:$CUDA_ROOT/lib64:$CUDA_ROOT/lib64/stubs:/usr/lib64
-          ./case.submit --no-batch 2>&1 | tee "$TMP_OUTPUT"
-          ################
-          # Pass or fail #
-          ################    
-          # Check the last 5 lines for 'failed' or 'error:' (case-insensitive)
-          if tail -n 5 "$TMP_OUTPUT" | grep -iE 'failed|error:'; then
-            exit 911
-          fi
+          aws s3 --no-verify-ssl --endpoint-url $AWS_ENDPOINT_URL sync /$TMP_DIR/ci_test/run/ s3://stormspeed/baselines/${{ matrix.runner }}/${{ matrix.compset }}_${{ matrix.res }}_${{ matrix.compiler }}_${{ matrix.dycore }}/ --region $AWS_DEFAULT_REGION --exclude "*" --include "*cam.h0a*.nc" --include "*cam.h0i*.nc" --include "*cam.i*.nc"
+
+      - name: Extract the netCDF output files from CIRRUS storage
+        if: env.GENERATE_BASELINE != 'true'
+        run: |
+          aws s3 --no-verify-ssl --endpoint-url $AWS_ENDPOINT_URL sync s3://stormspeed/baselines/${{ matrix.runner }}/${{ matrix.compset }}_${{ matrix.res }}_${{ matrix.compiler }}_${{ matrix.dycore }}/ /$TMP_DIR/ci_test/baselines/ --region $AWS_DEFAULT_REGION --exclude "*" --include "*cam.h0a*.nc" --include "*cam.h0i*.nc" --include "*cam.i*.nc"

--- a/.github/workflows/build_image_workflow.yml
+++ b/.github/workflows/build_image_workflow.yml
@@ -37,6 +37,10 @@ jobs:
           - dockerfile: Dockerfile.ubuntu24.04_nvhpc25.7_openmpi5.0.8_cuda12.9
             runner: gha-runner-gpu-stormspeed
     steps:
+      #This step sets up a varibale to use later in the image tag
+      - name: Get short sha
+        run: echo "SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_ENV
+        
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -59,10 +63,7 @@ jobs:
       - name: Set image name and tag
         run: |
             IMAGE_NAME=$(basename "${{ matrix.dockerfile }}" | sed 's/^Dockerfile\.//')
-            IMAGE_OS=$(echo "${IMAGE_NAME}" | cut -d'_' -f1)
-            IMAGE_TAG=$(echo "${IMAGE_NAME}" | cut -d'_' -f2-)
-            echo "IMAGE_OS=${IMAGE_OS}" >> $GITHUB_ENV
-            echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+            echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
 
       # Use the docker/build-push-action to build and push the image; the raw docker build and push commands does not work on CIRRUS
       - name: Build the Docker images
@@ -70,7 +71,7 @@ jobs:
         with:
           context: . # use the local workspace rather than a remote git URL; avoid a fresh clone and submodule update inside BuildKit
           push: true
-          tags: hub.k8s.ucar.edu/stormspeed/${{ env.IMAGE_OS }}:${{ env.IMAGE_TAG }}
+          tags: hub.k8s.ucar.edu/stormspeed/${{ env.IMAGE_NAME }}:${{ env.SHORT_SHA }}
           file: dockerfiles/${{ matrix.dockerfile }}
           no-cache: true # Do not use cache for the build
           #to utilize better image build caching using hub.k8s.ucar.edu

--- a/dockerfiles/Dockerfile.almalinux9.6_intel2024_openmpi5.0.8_cpu
+++ b/dockerfiles/Dockerfile.almalinux9.6_intel2024_openmpi5.0.8_cpu
@@ -17,8 +17,15 @@ WORKDIR /opt
 RUN dnf -y update && \
     dnf -y groupinstall "Development Tools" && \
     dnf -y install bzip2 bzip2-devel xz xz-devel gmp-devel mpfr-devel libmpc-devel zlib-devel && \
-    dnf -y install python3 git make wget gzip perl && \
+    dnf -y install python3 git make wget gzip perl unzip curl --allowerasing && \
     dnf -y install gcc-gfortran
+
+# Install AWS CLI v2 for AlmaLinux 9.6
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws && \
+    aws --version
 
 # Clone Spack with tag v1.0.0
 RUN git clone --depth=2 --branch v1.0.0 https://github.com/spack/spack.git
@@ -47,12 +54,14 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
 FROM intel_compiler AS xml2_cmake
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install cmake@3.31.8 %gcc
+    spack install cmake@3.31.8 %gcc && \
+    ln -s $(spack location -i cmake@3.31.8)/bin/cmake /usr/local/bin/cmake
     
 # Install xmllint that is required by CIME
 # Somehow libxml2 will be built by gcc anyway during other stage, so we just use gcc here to avoid confliction
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install libxml2@2.13.5 %gcc
+    spack install libxml2@2.13.5 %gcc && \
+    ln -s $(spack location -i libxml2@2.13.5)/bin/xmllint /usr/local/bin/xmllint
 
 #########################
 # Build ucx and openmpi #
@@ -63,7 +72,8 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
     spack install ucx@1.18.1 %intel-oneapi-compilers@2024.2.1
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install openmpi@5.0.8 fabrics=cma,ucx %intel-oneapi-compilers@2024.2.1 ^ucx@1.18.1
+    spack install openmpi@5.0.8 fabrics=cma,ucx %intel-oneapi-compilers@2024.2.1 ^ucx@1.18.1 && \
+    ln -s $(spack location -i openmpi@5.0.8) /usr/local/openmpi
 
 #############
 # Build MKL #
@@ -71,7 +81,8 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
 FROM ucx_openmpi AS mkl
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install intel-oneapi-mkl@2024.2.2 %intel-oneapi-compilers@2024.2.1 ^openmpi@5.0.8
+    spack install intel-oneapi-mkl@2024.2.2 %intel-oneapi-compilers@2024.2.1 ^openmpi@5.0.8 && \
+    ln -s $(spack location -i intel-oneapi-mkl@2024.2.2)/mkl/2024.2 /usr/local/mkl
 
 #########################
 # Build parallel-netcdf #
@@ -79,7 +90,8 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
 FROM mkl AS parallel_netcdf
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install parallel-netcdf@1.14.0 +cxx +fortran +pic +shared %intel-oneapi-compilers@2024.2.1 ^openmpi@5.0.8
+    spack install parallel-netcdf@1.14.0 +cxx +fortran +pic +shared %intel-oneapi-compilers@2024.2.1 ^openmpi@5.0.8 && \
+    ln -s $(spack location -i parallel-netcdf@1.14.0) /usr/local/pnetcdf
 
 ################
 # Build netCDF #
@@ -87,11 +99,13 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
 FROM parallel_netcdf AS netcdf
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netcdf-c@4.9.2 %intel-oneapi-compilers@2024.2.1 ^openmpi@5.0.8 ^parallel-netcdf@1.14.0
+    spack install netcdf-c@4.9.2 %intel-oneapi-compilers@2024.2.1 ^openmpi@5.0.8 ^parallel-netcdf@1.14.0 && \
+    ln -s $(spack location -i netcdf-c@4.9.2) /usr/local/netcdf_c
 
 # Install netcdf-fortran; it will install the netcdf-c and openmpi dependency by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netcdf-fortran@4.6.1 %intel-oneapi-compilers@2024.2.1 ^netcdf-c@4.9.2 ^openmpi@5.0.8
+    spack install netcdf-fortran@4.6.1 %intel-oneapi-compilers@2024.2.1 ^netcdf-c@4.9.2 ^openmpi@5.0.8 && \
+    ln -s $(spack location -i netcdf-fortran@4.6.1) /usr/local/netcdf_fortran
 
 #############
 # Build PIO #
@@ -100,7 +114,8 @@ FROM netcdf AS parallelio
 
 # Install parallelio; it will install the parallel-netcdf dependency by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install parallelio@2.6.6 +pnetcdf +fortran +mpi +shared +ncint %intel-oneapi-compilers@2024.2.1 ^parallel-netcdf@1.14.0
+    spack install parallelio@2.6.6 +pnetcdf +fortran +mpi +shared +ncint %intel-oneapi-compilers@2024.2.1 ^parallel-netcdf@1.14.0 && \
+    ln -s $(spack location -i parallelio@2.6.6) /usr/local/pio
 
 ##############
 # Build ESMF #
@@ -109,23 +124,43 @@ FROM parallelio AS esmf
 
 # Install ESMF; it will install its parallelio and parallel-netcdf dependencies by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install esmf@8.8.1 +pnetcdf +mpi +shared %intel-oneapi-compilers@2024.2.1 ^parallelio@2.6.6 ^parallel-netcdf@1.14.0
+    spack install esmf@8.8.1 +pnetcdf +mpi +shared %intel-oneapi-compilers@2024.2.1 ^parallelio@2.6.6 ^parallel-netcdf@1.14.0 && \
+    ln -s $(spack location -i esmf@8.8.1) /usr/local/esmf
 
 ################
 # Build LAPACK #
 ################
-FROM esmf AS lapack
+FROM esmf AS final_image
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netlib-lapack@3.12.1 %intel-oneapi-compilers@2024.2.1
+    spack install netlib-lapack@3.12.1 %intel-oneapi-compilers@2024.2.1 && \
+    ln -s $(spack location -i netlib-lapack@3.12.1) /usr/local/lapack
 
+################################################
+# Set up environment variables for CI workflow #
+################################################
+ENV CXX=icpx
+ENV CC=icx
+ENV FC=ifort
+ENV MPI_ROOT="/usr/local/openmpi"
+ENV NETCDF_C_PATH="/usr/local/netcdf_c"
+ENV NETCDF_FORTRAN_PATH="/usr/local/netcdf_fortran"
+ENV PNETCDF="/usr/local/pnetcdf"
+ENV PIO="/usr/local/pio"
+ENV ESMFMKFILE="/usr/local/esmf/lib/esmf.mk"
+ENV LAPACK="/usr/local/lapack"
+ENV PIO_VERSION_MAJOR=2
+ENV PIO_TYPENAME_VALID_VALUES="netcdf, pnetcdf, netcdf4c, netcdf4p"
+ENV MKLROOT="/usr/local/mkl"
+ENV PATH="/usr/local:/usr/local/bin:$MPI_ROOT/bin:${PATH}"
+ENV USER=robot
+
+##########################
+# Miscellaneous settings #
+##########################
 WORKDIR /tmp
 
 LABEL maintainer="Jian Sun"
 LABEL description="AlmaLinux 9.6 container with intel/2024.2.1 software stack for StormSPEED CAM"
-
-ENV CXX=icpx
-ENV CC=icx
-ENV FC=ifort
 
 CMD ["/bin/bash"]

--- a/dockerfiles/Dockerfile.opensuse15_gcc12_openmpi5.0.8_cpu
+++ b/dockerfiles/Dockerfile.opensuse15_gcc12_openmpi5.0.8_cpu
@@ -17,11 +17,18 @@ RUN zypper --non-interactive refresh && \
     zypper --non-interactive update && \
     zypper --non-interactive install -t pattern devel_basis && \
     zypper --non-interactive install bzip2 libbz2-devel xz xz-devel gmp-devel mpfr-devel mpc-devel zlib-devel && \
-    zypper --non-interactive install python3 git make wget gzip && \
+    zypper --non-interactive install python3 git make wget gzip unzip curl && \
     zypper --non-interactive install gcc12 gcc12-c++ gcc12-fortran && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 120 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 120 && \
     update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-12 120
+
+# Install AWS CLI v2
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws && \
+    aws --version
 
 # Clone Spack with tag v1.0.0
 RUN git clone --depth=2 --branch v1.0.0 https://github.com/spack/spack.git
@@ -39,10 +46,12 @@ FROM spack_base AS xml2_cmake
 
 # Install xmllint that is required by CIME
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install libxml2@2.13.5
+    spack install libxml2@2.13.5 && \
+    ln -s $(spack location -i libxml2@2.13.5)/bin/xmllint /usr/local/bin/xmllint
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install cmake@3.31.8
+    spack install cmake@3.31.8 && \
+    ln -s $(spack location -i cmake@3.31.8)/bin/cmake /usr/local/bin/cmake
 
 #########################
 # Build ucx and openmpi #
@@ -53,7 +62,8 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
     spack install ucx@1.18.1
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install openmpi@5.0.8 fabrics=cma,ucx ^ucx@1.18.1
+    spack install openmpi@5.0.8 fabrics=cma,ucx ^ucx@1.18.1 && \
+    ln -s $(spack location -i openmpi@5.0.8) /usr/local/openmpi
 
 #########################
 # Build parallel-netcdf #
@@ -61,7 +71,8 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
 FROM ucx_openmpi AS parallel_netcdf
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install parallel-netcdf@1.14.0 +cxx +fortran +pic +shared ^openmpi@5.0.8
+    spack install parallel-netcdf@1.14.0 +cxx +fortran +pic +shared ^openmpi@5.0.8 && \
+    ln -s $(spack location -i parallel-netcdf@1.14.0) /usr/local/pnetcdf
 
 ################
 # Build netCDF #
@@ -69,11 +80,13 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
 FROM parallel_netcdf AS netcdf
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netcdf-c@4.9.2 ^openmpi@5.0.8 ^parallel-netcdf@1.14.0
+    spack install netcdf-c@4.9.2 ^openmpi@5.0.8 ^parallel-netcdf@1.14.0 && \
+    ln -s $(spack location -i netcdf-c@4.9.2) /usr/local/netcdf_c
 
 # Install netcdf-fortran; it will install the netcdf-c and openmpi dependency by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netcdf-fortran@4.6.1 ^netcdf-c@4.9.2 ^openmpi@5.0.8
+    spack install netcdf-fortran@4.6.1 ^netcdf-c@4.9.2 ^openmpi@5.0.8 && \
+    ln -s $(spack location -i netcdf-fortran@4.6.1) /usr/local/netcdf_fortran
 
 #############
 # Build PIO #
@@ -82,7 +95,8 @@ FROM netcdf AS parallelio
 
 # Install parallelio; it will install the parallel-netcdf dependency by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install parallelio@2.6.6 +pnetcdf +fortran +mpi +shared +ncint ^parallel-netcdf@1.14.0
+    spack install parallelio@2.6.6 +pnetcdf +fortran +mpi +shared +ncint ^parallel-netcdf@1.14.0 && \
+    ln -s $(spack location -i parallelio@2.6.6) /usr/local/pio
 
 ##############
 # Build ESMF #
@@ -91,23 +105,42 @@ FROM parallelio AS esmf
 
 # Install ESMF; it will install its parallelio and parallel-netcdf dependencies by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install esmf@8.8.1 +pnetcdf +mpi +shared ^parallelio@2.6.6 ^parallel-netcdf@1.14.0
+    spack install esmf@8.8.1 +pnetcdf +mpi +shared ^parallelio@2.6.6 ^parallel-netcdf@1.14.0 && \
+    ln -s $(spack location -i esmf@8.8.1) /usr/local/esmf
 
 ################
 # Build LAPACK #
 ################
-FROM esmf AS lapack
+FROM esmf AS final_image
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netlib-lapack@3.12.1
+    spack install netlib-lapack@3.12.1 && \
+    ln -s $(spack location -i netlib-lapack@3.12.1) /usr/local/lapack
 
+################################################
+# Set up environment variables for CI workflow #
+################################################
+ENV CXX=g++
+ENV CC=gcc
+ENV FC=gfortran
+ENV MPI_ROOT="/usr/local/openmpi"
+ENV NETCDF_C_PATH="/usr/local/netcdf_c"
+ENV NETCDF_FORTRAN_PATH="/usr/local/netcdf_fortran"
+ENV PNETCDF="/usr/local/pnetcdf"
+ENV PIO="/usr/local/pio"
+ENV ESMFMKFILE="/usr/local/esmf/lib/esmf.mk"
+ENV LAPACK="/usr/local/lapack"
+ENV PIO_VERSION_MAJOR=2
+ENV PIO_TYPENAME_VALID_VALUES="netcdf, pnetcdf, netcdf4c, netcdf4p"
+ENV PATH="/usr/local:/usr/local/bin:$MPI_ROOT/bin:${PATH}"
+ENV USER=robot
+
+##########################
+# Miscellaneous settings #
+##########################
 WORKDIR /tmp
 
 LABEL maintainer="Jian Sun"
 LABEL description="openSUSE Leap 15 container with gcc/12.3.0 software stack for StormSPEED CAM"
-
-ENV CXX=g++
-ENV CC=gcc
-ENV FC=gfortran
 
 CMD ["/bin/bash"]

--- a/dockerfiles/Dockerfile.opensuse15_gcc12_openmpi5.0.8_cuda12.9
+++ b/dockerfiles/Dockerfile.opensuse15_gcc12_openmpi5.0.8_cuda12.9
@@ -16,11 +16,18 @@ RUN zypper --non-interactive refresh && \
     zypper --non-interactive update && \
     zypper --non-interactive install -t pattern devel_basis && \
     zypper --non-interactive install bzip2 libbz2-devel xz xz-devel gmp-devel mpfr-devel mpc-devel zlib-devel && \
-    zypper --non-interactive install python3 git make wget gzip && \
+    zypper --non-interactive install python3 git make wget gzip unzip curl && \
     zypper --non-interactive install gcc12 gcc12-c++ gcc12-fortran && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 120 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 120 && \
     update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-12 120
+
+# Install AWS CLI v2
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws && \
+    aws --version
 
 # Clone Spack with tag v1.0.0
 RUN git clone --depth=2 --branch v1.0.0 https://github.com/spack/spack.git
@@ -38,10 +45,12 @@ FROM spack_base AS xml2_cmake
 
 # Install xmllint that is required by CIME
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install libxml2@2.13.5
+    spack install libxml2@2.13.5 && \
+    ln -s $(spack location -i libxml2@2.13.5)/bin/xmllint /usr/local/bin/xmllint
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install cmake@3.31.8
+    spack install cmake@3.31.8 && \
+    ln -s $(spack location -i cmake@3.31.8)/bin/cmake /usr/local/bin/cmake
 
 ##############
 # Build cuda #
@@ -50,13 +59,14 @@ FROM xml2_cmake AS cuda
 
 # Install CUDA 12.9.0
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install cuda@12.9.0
+    spack install cuda@12.9.0 && \
+    ln -s $(spack location -i cuda@12.9.0) /usr/local/cuda
 
 # Remove unused CUDA SDK packages
 RUN . /opt/spack/share/spack/setup-env.sh && \
     cd $(spack location -i cuda@12.9.0) && \
     rm -rf nsight*
-    
+
 #########################
 # Build ucx and openmpi #
 #########################
@@ -66,7 +76,8 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
     spack install ucx@1.18.1 +cuda +cma +dm cuda_arch=86 ^cuda@12.9.0
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install openmpi@5.0.8 fabrics=cma,ucx,ofi +cuda cuda_arch=86 ^ucx@1.18.1 ^cuda@12.9.0
+    spack install openmpi@5.0.8 fabrics=cma,ucx,ofi +cuda cuda_arch=86 ^ucx@1.18.1 ^cuda@12.9.0 && \
+    ln -s $(spack location -i openmpi@5.0.8) /usr/local/openmpi
 
 #########################
 # Build parallel-netcdf #
@@ -74,7 +85,8 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
 FROM ucx_openmpi AS parallel_netcdf
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install parallel-netcdf@1.14.0 +cxx +fortran +pic +shared ^openmpi@5.0.8
+    spack install parallel-netcdf@1.14.0 +cxx +fortran +pic +shared ^openmpi@5.0.8 && \
+    ln -s $(spack location -i parallel-netcdf@1.14.0) /usr/local/pnetcdf
 
 ################
 # Build netCDF #
@@ -82,11 +94,13 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
 FROM parallel_netcdf AS netcdf
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netcdf-c@4.9.2 ^openmpi@5.0.8 ^parallel-netcdf@1.14.0
+    spack install netcdf-c@4.9.2 ^openmpi@5.0.8 ^parallel-netcdf@1.14.0 && \
+    ln -s $(spack location -i netcdf-c@4.9.2) /usr/local/netcdf_c
 
 # Install netcdf-fortran; it will install the netcdf-c and openmpi dependency by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netcdf-fortran@4.6.1 ^netcdf-c@4.9.2 ^openmpi@5.0.8
+    spack install netcdf-fortran@4.6.1 ^netcdf-c@4.9.2 ^openmpi@5.0.8 && \
+    ln -s $(spack location -i netcdf-fortran@4.6.1) /usr/local/netcdf_fortran
 
 #############
 # Build PIO #
@@ -95,7 +109,8 @@ FROM netcdf AS parallelio
 
 # Install parallelio; it will install the parallel-netcdf dependency by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install parallelio@2.6.6 +pnetcdf +fortran +mpi +shared +ncint ^parallel-netcdf@1.14.0
+    spack install parallelio@2.6.6 +pnetcdf +fortran +mpi +shared +ncint ^parallel-netcdf@1.14.0 && \
+    ln -s $(spack location -i parallelio@2.6.6) /usr/local/pio
 
 ##############
 # Build ESMF #
@@ -104,23 +119,43 @@ FROM parallelio AS esmf
 
 # Install ESMF; it will install its parallelio and parallel-netcdf dependencies by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install esmf@8.8.1 +pnetcdf +mpi +shared ^parallelio@2.6.6 ^parallel-netcdf@1.14.0
+    spack install esmf@8.8.1 +pnetcdf +mpi +shared ^parallelio@2.6.6 ^parallel-netcdf@1.14.0 && \
+    ln -s $(spack location -i esmf@8.8.1) /usr/local/esmf
 
 ################
 # Build LAPACK #
 ################
-FROM esmf AS lapack
+FROM esmf AS final_image
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netlib-lapack@3.12.1
+    spack install netlib-lapack@3.12.1 && \
+    ln -s $(spack location -i netlib-lapack@3.12.1) /usr/local/lapack
 
+################################################
+# Set up environment variables for CI workflow #
+################################################
+ENV CXX=g++
+ENV CC=gcc
+ENV FC=gfortran
+ENV MPI_ROOT="/usr/local/openmpi"
+ENV NETCDF_C_PATH="/usr/local/netcdf_c"
+ENV NETCDF_FORTRAN_PATH="/usr/local/netcdf_fortran"
+ENV PNETCDF="/usr/local/pnetcdf"
+ENV PIO="/usr/local/pio"
+ENV ESMFMKFILE="/usr/local/esmf/lib/esmf.mk"
+ENV LAPACK="/usr/local/lapack"
+ENV CUDA_ROOT="/usr/local/cuda"
+ENV PIO_VERSION_MAJOR=2
+ENV PIO_TYPENAME_VALID_VALUES="netcdf, pnetcdf, netcdf4c, netcdf4p"
+ENV PATH="/usr/local:/usr/local/bin:$MPI_ROOT/bin:$CUDA_ROOT/bin:${PATH}"
+ENV USER=robot
+
+##########################
+# Miscellaneous settings #
+##########################
 WORKDIR /tmp
 
 LABEL maintainer="Jian Sun"
 LABEL description="openSUSE Leap 15 container with gcc/12.3.0 and cuda/12.9.0 software stack for StormSPEED CAM"
-
-ENV CXX=g++
-ENV CC=gcc
-ENV FC=gfortran
 
 CMD ["/bin/bash"]

--- a/dockerfiles/Dockerfile.ubuntu24.04_nvhpc25.7_openmpi4.1.5_cpu
+++ b/dockerfiles/Dockerfile.ubuntu24.04_nvhpc25.7_openmpi4.1.5_cpu
@@ -15,8 +15,16 @@ WORKDIR /opt
 # Install python3 as prerequisite for Spack
 # This image also comes with gcc/13.3.0 compiler
 RUN apt-get update && \
-    apt-get install -y python3 && \
+    apt-get install -y python3 unzip curl && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 80 && \
     rm -rf /var/lib/apt/lists/*
+
+# Install AWS CLI v2
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws && \
+    aws --version
 
 # Clean up unused packages
 RUN cd /opt/nvidia/hpc_sdk/Linux_x86_64/25.7 && \
@@ -34,7 +42,8 @@ FROM spack_base AS xml2
 # This image comes with cmake/3.28.3
 # The xmllint built by NVHPC does not work; so we switch to gcc
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install libxml2@2.13.5 %gcc
+    spack install libxml2@2.13.5 %gcc && \
+    ln -s $(spack location -i libxml2@2.13.5)/bin/xmllint /usr/local/bin/xmllint
 
 #################
 # Build openmpi #
@@ -43,11 +52,13 @@ FROM xml2 AS openmpi
 
 # This image comes with openmpi/4.1.5 and likely not cuda enabled;
 # We can register it as external package for Spack
+ENV MPI_ROOT=/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5
 RUN echo "  openmpi:" >> /root/.spack/packages.yaml && \
     echo "    externals:" >> /root/.spack/packages.yaml && \
     echo "    - spec: openmpi@4.1.5" >> /root/.spack/packages.yaml && \
-    echo "      prefix: /opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5" >> /root/.spack/packages.yaml && \
-    echo "    buildable: false" >> /root/.spack/packages.yaml
+    echo "      prefix: $MPI_ROOT" >> /root/.spack/packages.yaml && \
+    echo "    buildable: false" >> /root/.spack/packages.yaml && \
+    ln -s $MPI_ROOT /usr/local/openmpi
 
 #########################
 # Build parallel-netcdf #
@@ -60,7 +71,8 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
     spack install autoconf && \
     spack install automake && \
     spack install libtool && \
-    spack install parallel-netcdf@1.14.0 +cxx +fortran +pic +shared %nvhpc@25.7 ^openmpi@4.1.5
+    spack install parallel-netcdf@1.14.0 +cxx +fortran +pic +shared %nvhpc@25.7 ^openmpi@4.1.5 && \
+    ln -s $(spack location -i parallel-netcdf@1.14.0) /usr/local/pnetcdf
 
 ################
 # Build netCDF #
@@ -68,11 +80,13 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
 FROM parallel_netcdf AS netcdf
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netcdf-c@4.9.2 %nvhpc@25.7 ^parallel-netcdf@1.14.0 ^openmpi@4.1.5
+    spack install netcdf-c@4.9.2 %nvhpc@25.7 ^parallel-netcdf@1.14.0 ^openmpi@4.1.5 && \
+    ln -s $(spack location -i netcdf-c@4.9.2) /usr/local/netcdf_c
 
 # Install netcdf-fortran; it will install the netcdf-c and openmpi dependency by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netcdf-fortran@4.6.1 %nvhpc@25.7 ^netcdf-c@4.9.2 ^openmpi@4.1.5
+    spack install netcdf-fortran@4.6.1 %nvhpc@25.7 ^netcdf-c@4.9.2 ^openmpi@4.1.5 && \
+    ln -s $(spack location -i netcdf-fortran@4.6.1) /usr/local/netcdf_fortran
 
 #############
 # Build PIO #
@@ -81,7 +95,8 @@ FROM netcdf AS parallelio
 
 # Install parallelio; it will install the parallel-netcdf dependency by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install parallelio@2.6.6 +pnetcdf +fortran +mpi +shared +ncint %nvhpc@25.7 ^parallel-netcdf@1.14.0 ^openmpi@4.1.5
+    spack install parallelio@2.6.6 +pnetcdf +fortran +mpi +shared +ncint %nvhpc@25.7 ^parallel-netcdf@1.14.0 ^openmpi@4.1.5 && \
+    ln -s $(spack location -i parallelio@2.6.6) /usr/local/pio
 
 ##############
 # Build ESMF #
@@ -91,26 +106,43 @@ FROM parallelio AS esmf
 # Install ESMF; it will install its parallelio and parallel-netcdf dependencies by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
     spack install py-cython@3.0.12 && \
-    spack install esmf@8.8.1 +pnetcdf +mpi +shared %nvhpc@25.7 ^parallelio@2.6.6 ^parallel-netcdf@1.14.0 ^openmpi@4.1.5
+    spack install esmf@8.8.1 +pnetcdf +mpi +shared %nvhpc@25.7 ^parallelio@2.6.6 ^parallel-netcdf@1.14.0 ^openmpi@4.1.5 && \
+    ln -s $(spack location -i esmf@8.8.1) /usr/local/esmf
 
 ################
 # Build LAPACK #
 ################
-FROM esmf AS lapack
+FROM esmf AS final_image
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netlib-lapack@3.12.1 %nvhpc@25.7
+    spack install netlib-lapack@3.12.1 %nvhpc@25.7 && \
+    ln -s $(spack location -i netlib-lapack@3.12.1) /usr/local/lapack
 
+################################################
+# Set up environment variables for CI workflow #
+################################################
+ENV CXX=nvc++
+ENV CC=nvc
+ENV FC=nvfortran
+ENV NETCDF_C_PATH="/usr/local/netcdf_c"
+ENV NETCDF_FORTRAN_PATH="/usr/local/netcdf_fortran"
+ENV PNETCDF="/usr/local/pnetcdf"
+ENV PIO="/usr/local/pio"
+ENV ESMFMKFILE="/usr/local/esmf/lib/esmf.mk"
+ENV LAPACK="/usr/local/lapack"
+ENV PIO_VERSION_MAJOR=2
+ENV PIO_TYPENAME_VALID_VALUES="netcdf, pnetcdf, netcdf4c, netcdf4p"
+ENV PATH="/usr/local:/usr/local/bin:$MPI_ROOT/bin:${PATH}"
+ENV USER=robot
+# Set the default compiler for nvcc wrapper
+ENV NVCC_WRAPPER_DEFAULT_COMPILER=nvc++
+
+##########################
+# Miscellaneous settings #
+##########################
 WORKDIR /tmp
 
 LABEL maintainer="Jian Sun"
 LABEL description="Ubuntu 24.04 container with nvhpc/25.7 software stack for StormSPEED CAM"
-
-ENV CXX=nvc++
-ENV CC=nvc
-ENV FC=nvfortran
-# Set the default compiler for nvcc wrapper
-ENV NVCC_WRAPPER_DEFAULT_COMPILER=nvc++
-ENV MPI_ROOT=/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5
 
 CMD ["/bin/bash"]

--- a/dockerfiles/Dockerfile.ubuntu24.04_nvhpc25.7_openmpi5.0.8_cuda12.9
+++ b/dockerfiles/Dockerfile.ubuntu24.04_nvhpc25.7_openmpi5.0.8_cuda12.9
@@ -15,8 +15,20 @@ WORKDIR /opt
 # Install python3 as prerequisite for Spack
 # This image also comes with gcc/13.3.0 compiler
 RUN apt-get update && \
-    apt-get install -y python3 && \
+    apt-get install -y python3 unzip curl && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 80 && \
     rm -rf /var/lib/apt/lists/*
+
+# Install AWS CLI v2
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws && \
+    aws --version
+
+# Link CUDA 
+RUN ln -s /opt/nvidia/hpc_sdk/Linux_x86_64/25.7/cuda /usr/local/cuda && \
+    ln -s /opt/nvidia/hpc_sdk/Linux_x86_64/25.7/math_libs /usr/local/math_libs
 
 # Clean up unused packages
 RUN cd /opt/nvidia/hpc_sdk/Linux_x86_64/25.7 && \
@@ -34,7 +46,8 @@ FROM spack_base AS xml2
 # This image comes with cmake/3.28.3
 # The xmllint built by NVHPC does not work; so we switch to gcc
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install libxml2@2.13.5 %gcc
+    spack install libxml2@2.13.5 %gcc && \
+    ln -s $(spack location -i libxml2@2.13.5)/bin/xmllint /usr/local/bin/xmllint
 
 #################
 # Build openmpi #
@@ -43,7 +56,8 @@ FROM xml2 AS openmpi
 
 # Skip installing ucx as NVHPC can not build it
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install openmpi@5.0.8 fabrics=cma,ucx,ofi +cuda cuda_arch=86 %nvhpc@25.7
+    spack install openmpi@5.0.8 fabrics=cma,ucx,ofi +cuda cuda_arch=86 %nvhpc@25.7 && \
+    ln -s $(spack location -i openmpi@5.0.8) /usr/local/openmpi
 
 #########################
 # Build parallel-netcdf #
@@ -51,7 +65,8 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
 FROM openmpi AS parallel_netcdf
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install parallel-netcdf@1.14.0 +cxx +fortran +pic +shared %nvhpc@25.7 ^openmpi@5.0.8
+    spack install parallel-netcdf@1.14.0 +cxx +fortran +pic +shared %nvhpc@25.7 ^openmpi@5.0.8 && \
+    ln -s $(spack location -i parallel-netcdf@1.14.0) /usr/local/pnetcdf
 
 ################
 # Build netCDF #
@@ -59,11 +74,13 @@ RUN . /opt/spack/share/spack/setup-env.sh && \
 FROM parallel_netcdf AS netcdf
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netcdf-c@4.9.2 %nvhpc@25.7 ^openmpi@5.0.8 ^parallel-netcdf@1.14.0
+    spack install netcdf-c@4.9.2 %nvhpc@25.7 ^openmpi@5.0.8 ^parallel-netcdf@1.14.0 && \
+    ln -s $(spack location -i netcdf-c@4.9.2) /usr/local/netcdf_c
 
 # Install netcdf-fortran; it will install the netcdf-c and openmpi dependency by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netcdf-fortran@4.6.1 %nvhpc@25.7 ^netcdf-c@4.9.2 ^openmpi@5.0.8
+    spack install netcdf-fortran@4.6.1 %nvhpc@25.7 ^netcdf-c@4.9.2 ^openmpi@5.0.8 && \
+    ln -s $(spack location -i netcdf-fortran@4.6.1) /usr/local/netcdf_fortran
 
 #############
 # Build PIO #
@@ -72,7 +89,8 @@ FROM netcdf AS parallelio
 
 # Install parallelio; it will install the parallel-netcdf dependency by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install parallelio@2.6.6 +pnetcdf +fortran +mpi +shared +ncint %nvhpc@25.7 ^parallel-netcdf@1.14.0 ^openmpi@5.0.8
+    spack install parallelio@2.6.6 +pnetcdf +fortran +mpi +shared +ncint %nvhpc@25.7 ^parallel-netcdf@1.14.0 ^openmpi@5.0.8 && \
+    ln -s $(spack location -i parallelio@2.6.6) /usr/local/pio
 
 ##############
 # Build ESMF #
@@ -82,27 +100,46 @@ FROM parallelio AS esmf
 # Install ESMF; it will install its parallelio and parallel-netcdf dependencies by default
 RUN . /opt/spack/share/spack/setup-env.sh && \
     spack install py-cython@3.0.12 && \
-    spack install esmf@8.8.1 +pnetcdf +mpi +shared %nvhpc@25.7 ^parallelio@2.6.6 ^parallel-netcdf@1.14.0 ^openmpi@5.0.8
+    spack install esmf@8.8.1 +pnetcdf +mpi +shared %nvhpc@25.7 ^parallelio@2.6.6 ^parallel-netcdf@1.14.0 ^openmpi@5.0.8 && \
+    ln -s $(spack location -i esmf@8.8.1) /usr/local/esmf
 
 ################
 # Build LAPACK #
 ################
-FROM esmf AS lapack
+FROM esmf AS final_image
 
 RUN . /opt/spack/share/spack/setup-env.sh && \
-    spack install netlib-lapack@3.12.1 %nvhpc@25.7
+    spack install netlib-lapack@3.12.1 %nvhpc@25.7 && \
+    ln -s $(spack location -i netlib-lapack@3.12.1) /usr/local/lapack
 
+################################################
+# Set up environment variables for CI workflow #
+################################################
+ENV CXX=nvc++
+ENV CC=nvc
+ENV FC=nvfortran
+ENV MPI_ROOT="/usr/local/openmpi"
+ENV NETCDF_C_PATH="/usr/local/netcdf_c"
+ENV NETCDF_FORTRAN_PATH="/usr/local/netcdf_fortran"
+ENV PNETCDF="/usr/local/pnetcdf"
+ENV PIO="/usr/local/pio"
+ENV ESMFMKFILE="/usr/local/esmf/lib/esmf.mk"
+ENV LAPACK="/usr/local/lapack"
+ENV PIO_VERSION_MAJOR=2
+ENV PIO_TYPENAME_VALID_VALUES="netcdf, pnetcdf, netcdf4c, netcdf4p"
+ENV CUDA_ROOT="/usr/local/cuda"
+ENV CUBLAS_ROOT="/usr/local/math_libs"
+ENV PATH="/usr/local:/usr/local/bin:$MPI_ROOT/bin:$CUDA_ROOT/bin:${PATH}"
+ENV USER=robot
+# Set the default compiler for nvcc wrapper
+ENV NVCC_WRAPPER_DEFAULT_COMPILER=nvc++
+
+##########################
+# Miscellaneous settings #
+##########################
 WORKDIR /tmp
 
 LABEL maintainer="Jian Sun"
 LABEL description="Ubuntu 24.04 container with nvhpc/25.7 and cuda/12.9 software stack for StormSPEED CAM"
-
-ENV CXX=nvc++
-ENV CC=nvc
-ENV FC=nvfortran
-# Set the default compiler for nvcc wrapper
-ENV NVCC_WRAPPER_DEFAULT_COMPILER=nvc++
-ENV CUDA_ROOT=/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/cuda
-ENV CUBLAS_ROOT=/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/math_libs
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
This PR adds the option to save the CI workflow output to the CIRRUS storage system, and pull the output back, which can serve as a baseline for comparison and verification check in the future.

I also simplify the workflow by moving lots of env variables settings into the image itself.

The CIRRUS storage system is S3 compatible so we also update the images with `aws cli` tool installed.

fix #61 