### PR TITLE
Update the workflow setup for external contributors

### DIFF
--- a/.github/workflows/build_and_run_workflow.yml
+++ b/.github/workflows/build_and_run_workflow.yml
@@ -6,6 +6,8 @@ on:
       - stormspeed
   pull_request_target:
     types: [labeled] # Only trigger when a label is added
+    branches:
+      - stormspeed
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build_and_run_workflow.yml
+++ b/.github/workflows/build_and_run_workflow.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - stormspeed
   pull_request_target:
-    types: [labeled] # Only trigger when a label is added or removed
+    types: [labeled] # Only trigger when a label is added
   workflow_dispatch:
 
 concurrency:
@@ -14,10 +14,8 @@ concurrency:
 
 jobs:
   build-and-run-on-CIRRUS:
-    # This 'if' condition is the key:
-    # 1. It checks that the event was a label being ADDED.
-    # 2. It checks that the label name is exactly 'ready_for_ci'.
-    if: github.event.action == 'labeled' && github.event.label.name == 'ready_for_ci'
+    # Run the CI workflow on CIRRUS only when the 'ready_for_ci' label is added to a pull request
+    if: github.event_name == 'pull_request_target' && github.event.label.name == 'ready_for_ci'
     name: Run ${{ matrix.image }} on ${{ matrix.runner }}
     env:
       TMP_DIR: tmp

--- a/.github/workflows/build_and_run_workflow.yml
+++ b/.github/workflows/build_and_run_workflow.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - stormspeed
-  pull_request:
+  pull_request_target:
+    types: [labeled] # Only trigger when a label is added or removed
   workflow_dispatch:
 
 concurrency:
@@ -13,6 +14,10 @@ concurrency:
 
 jobs:
   build-and-run-on-CIRRUS:
+    # This 'if' condition is the key:
+    # 1. It checks that the event was a label being ADDED.
+    # 2. It checks that the label name is exactly 'ready_for_ci'.
+    if: github.event.action == 'labeled' && github.event.label.name == 'ready_for_ci'
     name: Run ${{ matrix.image }} on ${{ matrix.runner }}
     env:
       TMP_DIR: tmp


### PR DESCRIPTION
This PR updates the CI workflow setup so that it can be triggered for a pull request from an external contributor (non-maintainer of StormSPEED repo).

The basic steps will be:

1. One reviewer (with write permission) will review the PR from the external contributor.
2. If it looks good, the reviewer will add the label `ready_for_ci` in the `Labels` section.
3. (Hopefully) the CI workflows are triggered correctly on the CIRRUS cloud.
4. If all the tests pass as expected, the reviewer can approve and merge the PR later.

fix #66 