### PR TITLE
Fix the restart issue at ne1024 resolution

### DIFF
--- a/.github/workflows/build_and_run_workflow.yml
+++ b/.github/workflows/build_and_run_workflow.yml
@@ -17,7 +17,12 @@ concurrency:
 jobs:
   build-and-run-on-CIRRUS:
     # Run the CI workflow on CIRRUS only when (1) it is a push action or (2) the 'ready_for_ci' label is added to a pull request
-    if: github.event_name == 'push' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ready_for_ci'))
+    if: >-
+      github.event_name == 'push' || 
+      (github.event_name == 'pull_request_target' && (
+        (github.event.action == 'labeled' && github.event.label.name == 'ready_for_ci') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ready_for_ci'))
+      ))
     name: Run ${{ matrix.image }} on ${{ matrix.runner }}
     env:
       TMP_DIR: tmp

--- a/.gitmodules
+++ b/.gitmodules
@@ -217,5 +217,5 @@ path = src/dynamics/senh/dycore
 url = https://github.com/E3SM-Project/E3SM.git
 fxrequired = AlwaysRequired
 fxsparse = ../.e3sm_sparse_checkout
-fxtag = cec3bb6
+fxtag = 057df66
 fxDONOTUSEurl = https://github.com/E3SM-Project/E3SM.git

--- a/src/dynamics/senh/restart_dynamics.F90
+++ b/src/dynamics/senh/restart_dynamics.F90
@@ -11,7 +11,7 @@ module restart_dynamics
 ! adjustments into the run.  The restart file containing the unstructured
 ! grid format may also be used for an initial run.
 
-use shr_kind_mod,     only: r8 => shr_kind_r8
+use shr_kind_mod,     only: r8 => shr_kind_r8, i8 => shr_kind_i8
 use spmd_utils,       only: iam, masterproc
 use control_mod_cam,  only: theta_hydrostatic_mode
 
@@ -302,7 +302,7 @@ subroutine write_elem()
    ! local variables
    integer          :: i, ie, j, k
    integer          :: ierr
-   integer, pointer :: ldof(:)
+   integer(i8), pointer :: ldof(:)
 
    type(io_desc_t)  :: iodesc2d, iodesc3d
    real(kind=r8), pointer :: var3d(:,:,:,:), var2d(:,:,:)
@@ -906,7 +906,7 @@ subroutine read_elem()
    integer :: ncol
    integer :: i, ie, ii, j, k, m
 
-   integer, pointer :: ldof(:)
+   integer(i8), pointer :: ldof(:)
 
    type(io_desc_t) :: iodesc2d, iodesc3d
    real(r8), allocatable :: var3d(:), var2d(:)
@@ -1390,9 +1390,11 @@ function get_restart_decomp(elem, lev) result(ldof)
 
    type(element_t), intent(in) :: elem(:)
    integer,         intent(in) :: lev
-   integer,         pointer    :: ldof(:)
+   integer(i8),     pointer    :: ldof(:)
 
-   integer :: i, j, k, ie
+   integer     :: i, j, k, ie
+   integer(i8) :: base ! force integer(i8) calculation
+
    !----------------------------------------------------------------------------
 
    allocate(ldof(nelemd*np*np*lev))
@@ -1400,8 +1402,9 @@ function get_restart_decomp(elem, lev) result(ldof)
    j = 1
    do k = 1, lev
       do ie = 1, nelemd
+         base = int(elem(ie)%GlobalID-1, i8)*np*np + int(k-1, i8)*nelem_tot*np*np
          do i = 1, np*np
-            ldof(j) = (elem(ie)%GlobalID-1)*np*np + (k-1)*nelem_tot*np*np + i
+            ldof(j) = base + i
             j = j + 1
          end do
       end do

--- a/src/utils/cam_grid_support.F90
+++ b/src/utils/cam_grid_support.F90
@@ -2856,7 +2856,7 @@ contains
   !
   !---------------------------------------------------------------------------
   subroutine cam_grid_set_map(this, map, src, dest)
-    use spmd_utils,      only: mpi_sum, mpi_integer, mpicom
+    use spmd_utils,      only: mpi_sum, mpi_integer, mpi_integer8, mpicom
     ! Dummy arguments
     class(cam_grid_t)                      :: this
     integer(iMap),     pointer             :: map(:,:)
@@ -2866,7 +2866,8 @@ contains
     ! Local variables
     integer                                :: dims(2)
     integer                                :: dstrt, dend
-    integer                                :: gridlen, gridloc, ierr
+    integer(iMap)                          :: gridlen, gridloc
+    integer                                :: ierr
 
     ! Check to make sure the map meets our needs
     call this%coord_lengths(dims)
@@ -2888,8 +2889,8 @@ contains
     else
       gridloc = count((map(dstrt,:) /= 0) .and. (map(dend,:) /= 0))
     end if
-    call MPI_Allreduce(gridloc, gridlen, 1, MPI_INTEGER, MPI_SUM, mpicom, ierr)
-    if (gridlen /= product(dims)) then
+    call MPI_Allreduce(gridloc, gridlen, 1, MPI_INTEGER8, MPI_SUM, mpicom, ierr)
+    if (gridlen /= product(int(dims,iMap))) then
       call endrun('cam_grid_set_map: Bad map size for '//trim(this%name))
     else
       if (.not. associated(this%map)) then

--- a/src/utils/cam_map_utils.F90
+++ b/src/utils/cam_map_utils.F90
@@ -673,6 +673,7 @@ contains
     character(len=SHR_KIND_CL)    :: errmsg
     character(len=32)             :: errfmt
     character(len=*), parameter   :: subname = 'cam_filemap_get_filemap: '
+    integer                       :: istat
 
     ! This shouldn't happen but, who knows what evil lurks in the hearts of SEs
     if (associated(filemap)) then
@@ -689,7 +690,11 @@ contains
     end if
 
     ! Allocate output filemap (dof)
-    allocate(filemap(product(fieldlens)))
+    allocate(filemap(product( int(fieldlens,kind=iMap) )), stat=istat)
+    if (istat/=0) then
+       call endrun(subname//': ERROR allocating array: filemap(product( int(fieldlens,kind=iMap) ))')
+    end if
+
     filemap = 0
 
     ! Find map source dimensions in input array


### PR DESCRIPTION
This pull request fixes the restart issue when running FADIAB compset at ne1024 resolution due to an integer overflow.

Basically we need to define the `ldof` variable as 64-bit integer and convert the calculation of its value to 64-bit integer as well before the assignment.

We also update the SE-NH dycore version to include our previous GPU code fix (https://github.com/E3SM-Project/E3SM/pull/7668).

fix #70 