### PR TITLE
Enable nonhydrostatic option for FV3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,10 +43,10 @@
 
 [submodule "fv3"]
 	path = src/dynamics/fv3
-	url = https://github.com/ESCOMP/CAM_FV3_interface.git
+	url = https://github.com/jtruesdal/CAM_FV3_interface.git
         fxrequired = AlwaysRequired
-        fxtag = fv3int_061924
-	fxDONOTUSEurl = https://github.com/ESCOMP/CAM_FV3_interface.git
+        fxtag = fv3int_nh_121825
+	fxDONOTUSEurl = https://github.com/jtruesdal/CAM_FV3_interface.git
 
 [submodule "geoschem"]
 	path = src/chemistry/geoschem/geoschem_src

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -4108,7 +4108,9 @@ if ($dyn eq 'fv') {
 
 # FV3 dycore
 if ( $dyn eq 'fv3') {
-
+    add_default($nl, 'fv3_a_imp');
+    add_default($nl, 'fv3_p_fac');
+    add_default($nl, 'fv3_use_logp');
     add_default($nl, 'fv3_adjust_dry_mass');
     add_default($nl, 'fv3_beta');
     add_default($nl, 'fv3_clock_grain');

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -3114,6 +3114,9 @@
 
 <fv3_print_memory_usage dyn="fv3">.true.</fv3_print_memory_usage>
 
+<fv3_a_imp                                                                  > 1.0D0     </fv3_a_imp>
+<fv3_p_fac                                                                  > 0.05D0    </fv3_p_fac>
+<fv3_use_logp                                                               > .false.   </fv3_use_logp>
 <fv3_adjust_dry_mass                                                        > .false.   </fv3_adjust_dry_mass>
 <fv3_beta                                                                   > 0         </fv3_beta>
 <fv3_consv_am                                                               > .false.   </fv3_consv_am>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -9352,6 +9352,42 @@ Default: none
 
 <!-- for fv3 dynamical core -->
 
+<entry id="fv3_a_imp" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: Controls behavior of the non-hydrostatic solver. Values greater
+than 0.5 enable the semi-implicit solver, in which the value of a_imp
+controls the time-off-centering: use a_imp = 1.0 for a fully backward
+time-stepping. For consistency, the sum of beta and a_imp should
+be 1 when the semi-implicit solver is used. The semi-implicit algo-
+rithm is substantially more efficient except at very high (km-scale)
+resolutions with an acoustic time step of a few seconds or less. 0.75
+by default. Proper values are 0, or between 0.5 and 1. This variable is
+only used if hydrostatic =.false.
+Default: 1.
+</entry>
+
+<entry id="fv3_p_fac" type="real" category="dyn_fv3"
+       group="fv_core_nml" valid_values="" >
+Real: Safety factor for minimum nonhydrostatic pressures, which
+will be limited so the full pressure is no less than p_fac times the
+hydrostatic pressure. This is only of concern in mid-top or high-
+top models with very low pressures near the model top, and has
+no effect in most simulations. The pressure limiting activates only
+when model is in danger of blowup due to unphysical negative
+total pressures. 0.05 by default. Only used if hydrostatic =.false.
+and the semi-implicit solver is used. Proper range is 0 to 0.25.
+Default: 0.05
+</entry>
+
+<entry id="fv3_use_logp" type="real" category="dyn_fv3"
+     group="fv_core_nml" valid_values="" >
+Logical: Enables a variant of the Lin pressure-gradient force 
+algorithm, which uses the logarithm of pressure instead of the Exner
+function (as in Lin 1997). This yields more accurate results for re-
+gions that are nearly isothermal. Ignored if hydrostatic = true.
+Default: FALSE
+</entry>
+
 <entry id="fv3_clock_grain" type="char*256" category="dyn_fv3"
        group="fms_nml" valid_values="" >
 The level of clock granularity used for performance timing sections

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -9379,7 +9379,7 @@ and the semi-implicit solver is used. Proper range is 0 to 0.25.
 Default: 0.05
 </entry>
 
-<entry id="fv3_use_logp" type="real" category="dyn_fv3"
+<entry id="fv3_use_logp" type="logical" category="dyn_fv3"
      group="fv_core_nml" valid_values="" >
 Logical: Enables a variant of the Lin pressure-gradient force 
 algorithm, which uses the logarithm of pressure instead of the Exner

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -372,8 +372,6 @@
       <value compset="_BGC%BDRD"> co2_cycle_rad_passive=.true. </value>
       <!-- hemco (harmonized emissions component) option -->
       <value compset="_CAM.*%HEMCO"> use_hemco=.true. </value>
-      <!-- rearth provided by FMS for FV3 and must remain fixed to that value to maintain consistency between phys/dyn. -->
-      <value grid="a%C[0-9]"> rearth = 6.37122D6 </value>
     </values>
     <group>run_component_cam</group>
     <file>env_run.xml</file>

--- a/src/dynamics/tests/initial_conditions/ic_baro_dry_jw06.F90
+++ b/src/dynamics/tests/initial_conditions/ic_baro_dry_jw06.F90
@@ -172,7 +172,7 @@ contains
     if (l3d_vars) then
       if (lu) nlev = size(U, 2)
       if (lv) nlev = size(V, 2)
-      if (lv) nlev = size(W, 2)
+      if (lw) nlev = size(W, 2)
       if (lt) nlev = size(T, 2)
       if (lq) nlev = size(Q, 2)
 

--- a/src/dynamics/tests/initial_conditions/ic_baroclinic.F90
+++ b/src/dynamics/tests/initial_conditions/ic_baroclinic.F90
@@ -223,7 +223,7 @@ contains
     if (l3d_vars) then
       if (lu) nlev = size(U, 2)
       if (lv) nlev = size(V, 2)
-      if (lv) nlev = size(W, 2)
+      if (lw) nlev = size(W, 2)
       if (lt) nlev = size(T, 2)
 
       if (lq) then

--- a/src/dynamics/tests/initial_conditions/ic_held_suarez.F90
+++ b/src/dynamics/tests/initial_conditions/ic_held_suarez.F90
@@ -22,7 +22,7 @@ module ic_held_suarez
 CONTAINS
 !==============================================================================
 
-  subroutine hs94_set_ic(latvals, lonvals, U, V, T, PS, PHIS,           &
+  subroutine hs94_set_ic(latvals, lonvals, U, V, W, T, PS, PHIS,         &
        Q, m_cnst, mask, verbose)
     use const_init,    only: cnst_init_default
     use constituents,  only: cnst_name
@@ -38,6 +38,7 @@ CONTAINS
     real(r8),           intent(in)    :: lonvals(:) ! lon in degrees (ncol)
     real(r8), optional, intent(inout) :: U(:,:)     ! zonal velocity
     real(r8), optional, intent(inout) :: V(:,:)     ! meridional velocity
+    real(r8), optional, intent(inout) :: W(:,:)     ! vertical velocity (nonhydrostatic)
     real(r8), optional, intent(inout) :: T(:,:)     ! temperature
     real(r8), optional, intent(inout) :: PS(:)      ! surface pressure
     real(r8), optional, intent(out)   :: PHIS(:)    ! surface geopotential
@@ -94,6 +95,18 @@ CONTAINS
       end do
       if(masterproc .and. verbose_use) then
         write(iulog,*) '          V initialized by "',subname,'"'
+      end if
+    end if
+
+    if (present(W)) then
+      nlev = size(W, 2)
+      do k = 1, nlev
+        where(mask_use)
+          W(:,k) = 0.0_r8
+        end where
+      end do
+      if(masterproc .and. verbose_use) then
+        write(iulog,*) '          W (nonhydrostatic) initialized by "',subname,'"'
       end if
     end if
 

--- a/src/dynamics/tests/initial_conditions/ic_us_standard_atm.F90
+++ b/src/dynamics/tests/initial_conditions/ic_us_standard_atm.F90
@@ -30,7 +30,7 @@ public :: us_std_atm_set_ic
 CONTAINS
 !=========================================================================================
 
-subroutine us_std_atm_set_ic(latvals, lonvals, zint, U, V, T, PS, PHIS_IN, &
+subroutine us_std_atm_set_ic(latvals, lonvals, zint, U, V, W, T, PS, PHIS_IN, &
        PHIS_OUT, Q, m_cnst, mask, verbose)
     
    !----------------------------------------------------------------------------
@@ -46,6 +46,7 @@ subroutine us_std_atm_set_ic(latvals, lonvals, zint, U, V, T, PS, PHIS_IN, &
    real(r8), optional, intent(in)    :: zint(:,:)  ! height at layer interfaces
    real(r8), optional, intent(inout) :: U(:,:)     ! zonal velocity
    real(r8), optional, intent(inout) :: V(:,:)     ! meridional velocity
+   real(r8), optional, intent(inout) :: W(:,:)     ! vertical velocity (nonhydrostatic)
    real(r8), optional, intent(inout) :: T(:,:)     ! temperature
    real(r8), optional, intent(inout) :: PS(:)      ! surface pressure
    real(r8), optional, intent(in)    :: PHIS_IN(:) ! surface geopotential
@@ -120,6 +121,19 @@ subroutine us_std_atm_set_ic(latvals, lonvals, zint, U, V, T, PS, PHIS_IN, &
          write(iulog,*) '          V initialized by '//subname
       end if
    end if
+
+   if (present(W)) then
+      nlev = size(W, 2)
+      do k = 1, nlev
+         where(mask_use)
+            W(:,k) = 0.0_r8
+         end where
+      end do
+      if(masterproc .and. verbose_use) then
+         write(iulog,*) '          W (nonhydrostatic) initialized by '//subname
+      end if
+   end if
+
 
    if (present(T)) then
       nlev = size(T, 2)


### PR DESCRIPTION
These changes to enable nonhydrostatic mode were provided by Timothy Andrews.  In addition to Timothy's changes I modified the fv3_arrays.F90 file to allow the user to update the namelist variables rearth and omega to mimic the fv3 small_earth_scaling functionality.  For example to enable a 1/20th scaling add omega and rearth to the user_nl_cam namelist with values set to omega * 20 and rearth / 20.